### PR TITLE
ci/cd: Remove 'verify' custom command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,8 +85,6 @@ jobs:
       - pre_deploy
       - run: pip install twine
       - run: pip install wheel
-      # make sure git tag matches release version
-      - run: python setup.py verify
       - create_pypirc 
       - run: python setup.py sdist bdist_wheel upload
 


### PR DESCRIPTION
pbr does not allow users to subclass pbr's command class. This means
that the VerifyVersion custom command 'verify' defined in setup.py is
being overriden and hence, circleci does not recognize the 'verify'
command during the build and release process. This commit removes the
step to 'verify' that the git tag matches the release version.

Upstream bug opened for this issue here:
https://bugs.launchpad.net/pbr/+bug/1300381

Signed-off-by: Rose Judge <rjudge@vmware.com>