### PR TITLE
ci/cd: Fix typo in pypirc file creation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,12 @@ commands:
       - run:
           name: Create pypirc file
           command: |
+           echo -e "[distutils]" >> ~/.pypirc
+           echo -e "index-servers =" >> ~/.pypirc
+           echo -e "    pypi\n" >> ~/.pypirc
            echo -e "[pypi]" >> ~/.pypirc
-           echo -e "username = $R_PYPI_UN" >> ~/.pypirc
-           echo -e "password = $PYPI_PW" >> ~/.pypiruc
+           echo -e "username: $R_PYPI_UN" >> ~/.pypirc
+           echo -e "password: $PYPI_PW" >> ~/.pypirc
   pre_deploy:
     steps:
       - run:


### PR DESCRIPTION
Fix a typo on the naming of the ~/.pypirc file on the circleci test VM.
Also add a distutils section to list pypi as an index server and change
the '=' notation to ':'.

Signed-off-by: Rose Judge <rjudge@vmware.com>