### PR TITLE
release: Modify deployment steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,9 @@ jobs:
       - run: pip install twine
       - run: pip install wheel
       - create_pypirc 
-      - run: python setup.py sdist bdist_wheel upload
+      - run: python setup.py sdist bdist_wheel
+      - run: twine check dist/*
+      - run: twine upload dist/*
 
 workflows:
   version: 2

--- a/docs/releases/release_checklist.md
+++ b/docs/releases/release_checklist.md
@@ -14,7 +14,7 @@ This is a checklist for cutting a release
     * Compare the release versions of the requirements to the current requirements.txt file. Upgrade if necessary.
     * Run `pip install .` to install tern.
     * Run appropriate tests. Roll back requirements if necessary.
-    * When satisfied, run `pip-compile --output-file docs/releases/v<release>-requirements.txt`.
+    * When satisfied, run `pip-compile --generate-hashes --output-file docs/releases/v<release>-requirements.txt`.
 
 - [ ] Write release notes.
     * Summary


### PR DESCRIPTION
Some fixes to the deployment steps

- Do not use setuptools to upload and it looks like it doesn't
render markdown. Rather, use twine to check the formats and upload
to PyPI.
- During the creation of the pinned versioned requirements.txt
file, generate hashes.

Signed-off-by: Nisha K <nishak@vmware.com>