### PR TITLE
requirements: Add stevedore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@
 PyYAML>=5.1
 docker~=4.0
 requests~=2.22
+stevedore>=1.30


### PR DESCRIPTION
Installation was failing due to the addition of stevedore as a
direct dependency. This goes unnoticed by the current PR tests
because stevedore is an dependency of bandit.

Adding the loose requirements to be greater or equal to the current
version at this time.

Signed-off-by: Nisha K <nishak@vmware.com>