### PR TITLE
report: Add missing copyright and license header

### DIFF
--- a/tern/report/analyze.py
+++ b/tern/report/analyze.py
@@ -1,3 +1,12 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Analyze a container image
+"""
+
 import logging
 
 from tern.report import errors


### PR DESCRIPTION
Add Copyright header. It's still a VMware copyright as the code
was mostly moved from another file. The license header stays the
same for all files in the project.

Also added a string explaining the file function

Signed-off-by: Nisha K <nishak@vmware.com>