### PR TITLE
Add docs to create a dev env. when using vagrant

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,22 +103,27 @@ You may have already cloned the project and started working on it. If you're rea
 7. Highly recommended: If you want to set up your project for long-term open source contribution, I highly suggest following [this setup](https://github.com/nishakm/puns).
 
 ### Setting up a development environment on Mac and Windows
-1. [Install](https://github.com/vmware/tern#install) VirtualBox and Vagrant for mac or windows
-2. Run `git clone https://github.com/vmware/tern.git`
+1. [Install](https://github.com/tern-tools/tern#install) VirtualBox and Vagrant for Mac or Windows
+2. Run `git clone https://github.com/tern-tools/tern.git`
 3. Run `cd tern/vagrant`
 4. Run `vagrant up`
 5. Run `vagrant ssh`
-6. Run `pip3 install wheel`
-7. Run `cd /tern`
-8. Run `pip3 install -e.[dev]`
-This will install tern in development mode on windows and mac.
+6. Run `python3 -m venv ternenv`
+7. Run `cd ternenv`
+8. Run `source bin/activate`
+9. Run `cp -r /tern .`
+10. Run `cd tern`
+11. Run `pip3 install wheel`
+12. Run `pip3 install -e.[dev]`
+This will install tern at the tip of master on Windows and Mac.
 
 ### After making changes
-1. Run prospector from the project's root directory `prospector .`
-2. Fix any issues prospector brings up.
-3. Run bandit from the project's root directory `bandit -r .`
-4. Fix any issues bandit brings up.
-5. Test your changes.
+1. Install your changes in the development virtual environment `pip3 install -e.[dev]`
+2. Run prospector from the project's root directory `prospector .`
+3. Fix any issues prospector brings up.
+4. Run bandit from the project's root directory `bandit -r .`
+5. Fix any issues bandit brings up.
+6. Test your changes.
 
 ### Testing you changes
 After you make the changes just run `tox`. This will run a set tests and inform you if anything is wrong.

--- a/README.md
+++ b/README.md
@@ -133,11 +133,13 @@ Follow the instructions on the [VirtualBox](https://www.virtualbox.org/wiki/Down
 Follow the instructions on the website to install [Vagrant](https://www.vagrantup.com/downloads.html) for your OS. 
 
 ### Create a Vagrant environment
-In your terminal app, run the following commands.
+**NOTE**: The following steps will install the latest [PyPI release](https://pypi.org/project/tern/#history) version of Tern. If you want to install Tern from the tip of master, please instead follow "Setting up a development environment on Mac and Windows" in the [contributing guide](/CONTRIBUTING.md).
+
+In your terminal app, run the following commands. 
 
 Clone this repository:
 ```
-$ git clone https://github.com/vmware/tern.git
+$ git clone https://github.com/tern-tools/tern.git
 ```
 
 Bring up the Vagrant box: 


### PR DESCRIPTION
If Tern users follow the steps in the README to get started with
vagrant, they will end up using the bootstrap.sh file, which installs
the latest PyPI version of Tern. This is oftentimes all users need to
get started. If, however, they would like to pick up any new changes or
features thave have been merged since the release, they will need to
install Tern from the tip of master instead.

This commit updates the documentation in the README and CONTRIBUTING to
so that users can use vagrant and install Tern in a way that works for
their needs, either at the latest release version or in development mode
at the tip of master. It also updates the GitHub links in the vagrant
sections to refer to Tern's new org, tern-tools/tern.

Signed-off-by: Rose Judge <rjudge@vmware.com>