### PR TITLE
Add CI test for Dockerfile lock

### DIFF
--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -79,7 +79,8 @@ test_suite = {
         'python tests/test_analyze_docker_dockerfile.py',
         'python tests/test_analyze_common.py',
         'tern report -i golang:alpine',
-        'tern report -d samples/alpine_python/Dockerfile'],
+        'tern report -d samples/alpine_python/Dockerfile',
+        'tern lock Dockerfile'],
     # tern/report
     re.compile('tern/report'): [
         'tern report -i golang:alpine',


### PR DESCRIPTION
While it is impossible to verify the output of the Dockerfile lock
command without a controlled base OS and Dockerfile, we still want to
make sure that the Dockerfile lock command runs to completion when new
changes are merged from a PR. This commit adds the Dockerfile lock test
to run whenever files under the tern/analyze/docker directory are
changed.

Signed-off-by: Rose Judge <rjudge@vmware.com>