### PR TITLE
Extract Debian license data from copyright text

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -12,3 +12,4 @@ requests
 stevedore
 pbr
 dockerfile-parse
+debut

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ dockerfile-parse~=0.0
 requests~=2.23
 stevedore>=1.32
 pbr>=5.4
+debut>=0.9

--- a/tern/classes/package.py
+++ b/tern/classes/package.py
@@ -39,6 +39,7 @@ class Package:
         self.__checksum = ''
         self.__origins = Origins()
         self.__files = []
+        self.__pkg_licenses = []
 
     @property
     def name(self):
@@ -60,9 +61,17 @@ class Package:
     def pkg_license(self):
         return self.__pkg_license
 
+    @property
+    def pkg_licenses(self):
+        return self.__pkg_licenses
+
     @pkg_license.setter
     def pkg_license(self, pkg_license):
         self.__pkg_license = pkg_license
+
+    @pkg_licenses.setter
+    def pkg_licenses(self, pkg_licenses):
+        self.__pkg_licenses = pkg_licenses
 
     @property
     def copyright(self):

--- a/tern/formats/default/generator.py
+++ b/tern/formats/default/generator.py
@@ -67,27 +67,65 @@ def get_layer_info_list(layer):
         pkg = package.name + "-" + package.version
         if pkg not in layer_pkg_list and pkg:
             layer_pkg_list.append(pkg)
-        if package.pkg_license not in layer_license_list and \
-                package.pkg_license:
-            layer_license_list.append(package.pkg_license)
+
+        package_licenses = get_package_licenses(package)
+        for package_license in package_licenses:
+            if package_license not in layer_license_list:
+                layer_license_list.append(package_license)
+
     return layer_pkg_list, layer_license_list, file_level_licenses
+
+
+def get_package_licenses(package):
+    '''Given a package collect complete list of package licenses'''
+    pkg_licenses = set()
+    if package.pkg_license:
+        pkg_licenses.add(package.pkg_license)
+
+    if package.pkg_licenses:
+        for pkg_license in package.pkg_licenses:
+            if pkg_license:
+                pkg_licenses.add(pkg_license)
+
+    return list(pkg_licenses)
+
+
+def get_layer_packages_licenses(layer):
+    '''Given a image layer collect complete list of package licenses'''
+    pkg_licenses = set()
+    for package in layer.packages:
+        package_licenses = get_package_licenses(package)
+        for package_license in package_licenses:
+            pkg_licenses.add(package_license)
+
+    return list(pkg_licenses)
+
+
+def get_layer_files_licenses(layer):
+    '''Given a image layer collect complete list of file licenses'''
+    file_level_licenses = set()
+    for f in layer.files:
+        for license_expression in f.license_expressions:
+            if license_expression:
+                file_level_licenses.add(license_expression)
+
+    return list(file_level_licenses)
 
 
 def print_licenses_only(image_obj_list):
     '''Print a complete list of licenses for all images'''
-    full_license_list = []
+    full_licenses = set()
     for image in image_obj_list:
         for layer in image.layers:
-            for package in layer.packages:
-                if (package.pkg_license and
-                        package.pkg_license not in full_license_list):
-                    full_license_list.append(package.pkg_license)
+            pkg_licenses = get_layer_packages_licenses(layer)
+            for pkg_license in pkg_licenses:
+                full_licenses.add(pkg_license)
 
-            for f in layer.files:
-                for license_expression in f.license_expressions:
-                    if license_expression not in full_license_list:
-                        full_license_list.append(license_expression)
+            file_level_licenses = get_layer_files_licenses(layer)
+            for file_level_license in file_level_licenses:
+                full_licenses.add(file_level_license)
 
+    full_license_list = list(full_licenses)
     # Collect the full list of licenses from all the layers
     licenses = formats.full_licenses_list.format(list=", ".join(
         full_license_list) if full_license_list else 'None')

--- a/tests/test_class_package.py
+++ b/tests/test_class_package.py
@@ -145,7 +145,8 @@ class TestClassPackage(unittest.TestCase):
         p_dict = {'name': 'p1',
                   'version': '1.0',
                   'pkg_license': 'Apache 2.0',
-                  'checksum': 'abcxyz'}
+                  'checksum': 'abcxyz',
+                  'pkg_licenses': []}
         p = Package('p1')
         p.fill(p_dict)
         self.assertEqual(p.name, 'p1')


### PR DESCRIPTION
This PR does following,

1. It proposed a license extraction logic based
on `pkg_format`.
2. It proposed a change in `base.yml` file to extract
copyright file location instead of copyright text.
3. It adds `pkg_licenses` property in `Package`
class to record multiple liceses in a package.
4. It updates default report generator to
print multiple licenses of a packge.
5. It updates default generator to address
'to many brances' build error.

Work towards: #499

Signed-off-by: mukultaneja <mtaneja@vmware.com>