### PR TITLE
Combine RUN commands in Tern's Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,7 @@ FROM photon:3.0
 # install system dependencies
 # photon:3.0 comes with toybox which conflicts with some dependencies needed for tern to work, so uninstalling
 # toybox first
-RUN tdnf remove -y toybox && tdnf install -y tar findutils attr util-linux python3 python3-pip python3-setuptools git
-
-# install pip and tern
-RUN pip3 install --upgrade pip && pip3 install tern
+RUN tdnf remove -y toybox && tdnf install -y tar findutils attr util-linux python3 python3-pip python3-setuptools git && pip3 install --upgrade pip && pip3 install tern
 
 # make a mounting directory
 RUN mkdir hostmount

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -6,10 +6,7 @@ FROM photon:3.0
 # install system dependencies
 # photon:3.0 comes with toybox which conflicts with some dependencies needed for tern to work, so uninstalling
 # toybox first
-RUN tdnf remove -y toybox && tdnf install -y tar findutils attr util-linux python3 python3-pip python3-setuptools git
-
-# install pip
-RUN pip3 install --upgrade pip
+RUN tdnf remove -y toybox && tdnf install -y tar findutils attr util-linux python3 python3-pip python3-setuptools git && pip3 install --upgrade pip
 
 # install tern with latest changes
 COPY dist/tern-*.tar.gz .


### PR DESCRIPTION
This commit combines the two separate RUN commands in Tern's Dockerfile
and the Dockerfile used by the CI. Using one RUN command to install
packages reduces the amount of layers and overall footprint of the Tern
image.

Signed-off-by: Rose Judge <rjudge@vmware.com>