### PR TITLE
Run prospector on all files for CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - setup
       - run: pip install prospector>=1.2 GitPython~=2.1
       - run: pip install .
-      - run: c=`python ci/evaluate_docs.py`; if [ -z $c ]; then echo "No .py files to lint"; else echo $c | xargs prospector; fi
+      - run: prospector 
   # security linting using Bandit
   security:
     executor: ubuntu1604

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Prospector Linting
         run: |
           pip install prospector>=1.1
-          c=`python ci/evaluate_docs.py`; if [ -z $c ]; then echo "No .py files to lint"; else echo $c | xargs prospector; fi
+          prospector
       - name: Commit Message Linting
         if: always() # run even if above step fails
         run: python ci/test_commit_message.py


### PR DESCRIPTION
This commit changes the CI tests to run prospector on the entire tern
directory when a PR is opened instead of just the files that were
changed in the PR.

Before this commit, we were only running prospector on the files that
were changed in an attempt to avoid known linting failures being
reported. The known linting errors have been fixed, however, and we can
now run prospector on the full directory, which returns more accurate
results.

Signed-off-by: Rose Judge <rjudge@vmware.com>