### PR TITLE
utils: Exclude whiteout files when extracting

### DIFF
--- a/tern/utils/rootfs.py
+++ b/tern/utils/rootfs.py
@@ -21,7 +21,7 @@ remove = ['rm', '-rf']
 
 # tar commands
 check_tar = ['tar', '-tf']
-extract_tar = ['tar', '-xf']
+extract_tar = ['tar', '-x', '--exclude=.wh.*', '-f']
 
 # mount commands
 mount = ['mount', '-o', 'bind']


### PR DESCRIPTION
Container images using copy-on-write graph drivers often have
whiteout files in them if any files were deleted. These take the
form .wh.<deleted file> or .wh..wh..op. These are meant to be
treated as deleted. However, since they still exist on the
filesystem, they can still be accessed by scripts or executables.
This is the case with pip which is used to list pip packages. pip
will pick out a .wh.pip file if pip is upgraded. To get around this
general issue, we exclude files starting with a '.wh.' prefix when
extracting image tarballs.

Signed-off-by: Nisha K <nishak@vmware.com>