### PR TITLE
Fix infinite loop in container_debug.py

### DIFF
--- a/tern/tools/container_debug.py
+++ b/tern/tools/container_debug.py
@@ -122,7 +122,7 @@ if __name__ == '__main__':
                 if not 0 <= top_layer < len(image_obj.layers):
                     print("Not a valid layer number")
                     continue
-            drop_into_layer(image_obj, top_layer)
+                drop_into_layer(image_obj, top_layer)
         except KeyboardInterrupt:
             print("Exiting...")
             cleanup()


### PR DESCRIPTION
This commit fixes an infinite loop in the container_debug.py script that
was repeatedly prompting the user to "Pick a layer to debug" without
actually dropping in to that layer.

Signed-off-by: Rose Judge <rjudge@vmware.com>