### PR TITLE
WIP: Enable gem package listing

### DIFF
--- a/tern/command_lib/base.yml
+++ b/tern/command_lib/base.yml
@@ -213,3 +213,46 @@ rpm:
         container:
           - 'rpm --query --all --queryformat "%{url}\n" 2>/dev/null'
     delimiter: "\n"
+
+gem:
+  pkg_format: ''
+  os_guess:
+    - 'None'
+  path:
+    - 'usr/local/bin/gem'
+    - 'user/bin/gem'
+  shell: '/bin/bash' # could also be 'usr/bin/sh'
+  pkg_separators:
+    - '=='
+    - '<='
+    - '>='
+    - '<'
+    - '>'
+    - '~='
+  pinning_separator: '=='
+  names:
+    invoke:
+      1:
+        container:
+          - "gem list 2> /dev/null | awk '{print $1}'"
+    delimiter: "\n"
+  versions:
+    invoke:
+      1:
+        container:
+          - "gem list 2> /dev/null | awk '{print $2}' | awk -F'[()]' '{print $2}'"
+    delimiter: "\n"
+  licenses:
+    invoke:
+      1:
+        container:
+          - "pkgs=`gem list 2> /dev/null | awk '{print $1}'`"
+          - "for pkg in $pkgs;do gem info $pkg 2>/dev/null |grep -n 'License:'| awk '{print $3}'; done"
+    delimiter: "\n"
+  proj_urls:
+    invoke:
+      1:
+        container:
+          - "pkgs=`gem list 2> /dev/null | awk '{print $1}'`"
+          - "for pkg in $pkgs;do gem info $pkg 2>/dev/null |grep -n 'Homepage:'| awk '{print $3}'; done" 
+    delimiter: "\n"

--- a/tern/command_lib/snippets.yml
+++ b/tern/command_lib/snippets.yml
@@ -58,3 +58,14 @@ rpm:
    install: '-i'
    remove: '-e'
    packages: 'rpm'
+
+
+
+gem:
+  install: 'install'
+  remove: 'uninstall'
+  ignore:
+      - 'ls'
+      - 'list'
+      - 'restart'
+  packages: 'gem'


### PR DESCRIPTION
This commit adds changes to snippets.yml and base.yml to
collect the metadata of gem modules. Scripts are added
to base.yml to list the version, license, proj_url.

This PR is work towards #609.

Signed-off-by: abhaykatheria <abhaykatheria01@gmail.com>