### PR TITLE
Enable gem package listing

### DIFF
--- a/tern/command_lib/base.yml
+++ b/tern/command_lib/base.yml
@@ -301,3 +301,48 @@ pip3:
           - "pkgs=`pip3 list --format=freeze 2> /dev/null | cut -f1 -d'='`"
           - "for p in $pkgs; do pip3 show $p 2> /dev/null | head -7 | tail -1 | cut -f2 -d' '; done" 
     delimiter: "\n"
+gem:
+  pkg_format: ''
+  os_guess:
+    - 'None'
+  path:
+    - 'usr/local/bin/gem'
+  shell: '/bin/bash' # could also be 'usr/bin/sh'
+  pkg_separators:
+    - ':'
+    - '-v '
+    - '>='
+    - '<='
+    - '<'
+    - '>'
+    - '~>'
+    - '-v '
+  pinning_separator: ':'
+  names:
+    invoke:
+      1:
+        container:
+          - "gem list 2> /dev/null | cut -f1 -d' '"
+    delimiter: "\n"
+  versions:
+    invoke:
+      1:
+        container:
+          - "pkgs=`gem list 2> /dev/null | cut -f1 -d' '`"
+          - "for p in $pkgs; do gem list $p 2> /dev/null | head -2 | cut -f2 -d'(' | cut -f1 -d')' | cut -f2 -d' '; done" 
+    delimiter: "\n"
+  licenses:
+    invoke:
+      1:
+        container:
+          - "pkgs=`gem list 2> /dev/null | cut -f1 -d' '`"
+          # Output 'Unknown' if license is blank
+          - "for p in $pkgs; do lic=`gem spec $p license | head -1 | cut -f2 -d' '`; if [ -z $lic ]; then echo 'Unknown'; else echo $lic; fi; done"
+    delimiter: "\n"
+  proj_urls:
+    invoke:
+      1:
+        container:
+          - "pkgs=`gem list 2> /dev/null | awk '{print $1}'`"
+          - "for p in $pkgs; do proj_url=`gem spec $p homepage | head -1 | cut -f2 -d' '`; if [ -z $proj_url ]; then echo 'Unknown'; else echo $proj_url; fi; done"
+    delimiter: "\n"

--- a/tern/command_lib/snippets.yml
+++ b/tern/command_lib/snippets.yml
@@ -84,3 +84,15 @@ pip3:
      - 'hash'
      - 'wheel'
    packages: 'pip3'
+gem:
+  install: 'install'
+  remove: 'uninstall'
+  ignore:
+      - 'fetch'
+      - 'build'
+      - 'lock'
+      - 'unpack'
+      - 'cleanup'
+      - 'check'
+      - 'mirror'
+  packages: 'gem'


### PR DESCRIPTION
This commit adds commands to base.yml to collect gem packages,
versions, licenses and proj_url information using the gem language
package manager.

When the gem package manager does not have license or homepage
information for a package, it renders as a blank line. Since Tern
requires the number of packages to be the same number of elements as the
list of licenses, we print 'Unknown' as the license or homepage instead
of an empty license or proj_url value.

Works towards #609.

Signed-off-by: Rose Judge <rjudge@vmware.com>
Signed-off-by: abhaykatheria <abhaykatehria01@gmail.com>