### PR TITLE
Look for shell in filesystem

### DIFF
--- a/tern/command_lib/base.yml
+++ b/tern/command_lib/base.yml
@@ -5,7 +5,8 @@
 # Format to list images
 # <package manager>:
 #   pkg_format: <the package format used by the package manager>
-#   shell: <the shell executable> (needed if entering code snippets)
+#   os_guess: A list of strings that might indicate what kind of OS this package manager may apply to
+#   path: A list paths that this package manager may be present
 #   pkg_separators: Potential characters to separate package name from version. Some package managers will have more than one.
 #   pinning_separator: Character to denote package version in pinned Dockerfile (i.e. apk add package=version)
 #   names: <a list of package names>
@@ -23,7 +24,6 @@ tdnf:
     - 'Photon'
   path:
     - 'usr/bin/tdnf' # don't put forward slash here as os.path.join will think it is the root directory on the host
-  shell: '/usr/bin/bash'
   pkg_separators:
     - '-'
   pinning_separator: '-'
@@ -69,7 +69,6 @@ dpkg:
     - 'Ubuntu'
   path:
     - 'usr/bin/dpkg'
-  shell: '/bin/bash'
   pkg_separators:
     - '='
   pinning_separator: '='
@@ -105,7 +104,6 @@ apk:
     - 'Alpine Linux'
   path:
     - 'sbin/apk'
-  shell: '/bin/sh'
   pkg_separators:
     - '='
   pinning_separator: '='
@@ -146,7 +144,6 @@ pacman:
     - 'Arch Linux'
   path:
     - 'usr/bin/pacman'
-  shell: '/usr/bin/sh'
   pkg_separators:
     - '='
   pinning_separator: '='
@@ -185,7 +182,6 @@ rpm:
     - 'RHEL'
   path:
     - 'usr/bin/rpm'
-  shell: '/usr/bin/sh'
   pkg_separators:
     - '-'
   pinning_separator: '-'
@@ -220,7 +216,6 @@ pip:
     - 'None'
   path:
     - 'usr/local/bin/pip'
-  shell: '/bin/bash' # could also be 'usr/bin/sh'
   pkg_separators:
     - '=='
     - '<='
@@ -264,7 +259,6 @@ pip3:
     - 'None'
   path:
     - 'usr/local/bin/pip3'
-  shell: '/bin/bash' # could also be 'usr/bin/sh'
   pkg_separators:
     - '=='
     - '<='

--- a/tern/command_lib/command_lib.py
+++ b/tern/command_lib/command_lib.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 """
@@ -24,8 +24,13 @@ base_file = pkg_resources.resource_filename('tern', 'command_lib/base.yml')
 # general snippets in command library
 snippet_file = pkg_resources.resource_filename('tern',
                                                'command_lib/snippets.yml')
+# common information
+common_file = pkg_resources.resource_filename('tern', 'command_lib/common.yml')
+
 # command library
-command_lib = {'base': {}, 'snippets': {}}
+command_lib = {'common': {}, 'base': {}, 'snippets': {}}
+with open(os.path.abspath(common_file)) as f:
+    command_lib['common'] = yaml.safe_load(f)
 with open(os.path.abspath(base_file)) as f:
     command_lib['base'] = yaml.safe_load(f)
 with open(os.path.abspath(snippet_file)) as f:

--- a/tern/command_lib/command_lib.py
+++ b/tern/command_lib/command_lib.py
@@ -113,15 +113,6 @@ def check_library_key(listing, key):
         return {}, errors.unsupported_listing_for_key.format(listing_key=e)
 
 
-def get_image_shell(base_image_listing):
-    '''Given the base image listing return the image shell. If there is no
-    shell listing, return an empty string'''
-    shell, msg = check_library_key(base_image_listing, 'shell')
-    if not shell:
-        shell = ''
-    return shell, msg
-
-
 def get_package_listing(command_name):
     '''Given a command name, return the package listing from the snippet
     library.'''

--- a/tern/command_lib/common.yml
+++ b/tern/command_lib/common.yml
@@ -1,0 +1,12 @@
+# Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Known common aspects of container image filesystems
+
+# possible base OS shells
+shells:
+  - /bin/sh
+  - /usr/bin/sh
+  - /bin/bash
+  - /usr/bin/bash
+  - /bin/dash

--- a/tern/report/errors.py
+++ b/tern/report/errors.py
@@ -14,6 +14,7 @@ no_packages = '''Unable to recover packages for layer {layer_id}. ''' \
     '''retrieve the package in the command library.\n'''
 no_package_manager = '''Unable to find a known package manager. Cannot ''' \
     '''list packages.\n'''
+no_shell = '''No known shell found in image. Cannot invoke commands\n'''
 no_etc_release = '''Unknown base OS. Unable to find an os-release file.'''
 no_version = '''No version for package {package_name}. Consider either ''' \
     '''entering the version manually or creating a script to retrieve ''' \
@@ -47,9 +48,6 @@ no_command_listing = '''No listing of hardcoded or retrieval steps for ''' \
 incomplete_command_lib_listing = '''The command library has an incomplete ''' \
     '''listing for {image_name}:{image_tag}. Please complete the listing ''' \
     '''based on the examples.\n'''
-no_shell_listing = '''There is no listing for 'shell' under the base ''' \
-    '''listing for {binary}. Using default shell: ''' \
-    '''{default_shell}\n'''
 unknown_content = '''Unknown content included in layer {files}. Please ''' \
     '''analyze these files separately\n'''
 keyboard_interrupt = '''Keyboard Interrupt! Aborting analysis...'''


### PR DESCRIPTION
This PR resolves #644 where the shell existing on the filesystem
did not match the shell referenced in the command library for
the package manager. In general, filesystems may use any shell.
Hence, rather than making a one to one correspondence to the
package managers or any other binary, we list the shells in a
different location and try to search for them in the filesystem.

Commit 1 adds a new listing called 'common' to the command library
which contains a key called 'shells' which is a list of shells.

Commit 2 modifies the analyzer operation to look for any shell in the
filesystem.

Commit 3 removes the old 'shell' listing from the command library.

Signed-off-by: Nisha K <nishak@vmware.com>