### PR TITLE
Update `base.yml` to `echo` copyright file location for Debian image

### DIFF
--- a/tern/command_lib/base.yml
+++ b/tern/command_lib/base.yml
@@ -94,7 +94,7 @@ dpkg:
       1:
         container:
           - "pkgs=`dpkg --get-selections | cut -f1 -d':' | awk '{print $1}'`"
-          - "for p in $pkgs; do cat /usr/share/doc/$p/copyright; echo LICF; done"
+          - "for p in $pkgs; do echo /usr/share/doc/$p/copyright; echo LICF; done"
     delimiter: 'LICF'
   proj_urls: {}
 


### PR DESCRIPTION
This PR does following,

1. It updates the `dpkg` section inside `base.yml`
to `echo` copyright's file location instead `cat`
the copyright's text. This change would help to
parse Debian package’s copyright text and filter
license information using external utility
`debut`.
2.It addresses issue#565 which is, 'not
able to find `cat` command location in
$PATH for CENTOS systems'.

Resolved: #565

Signed-off-by: mukultaneja <mtaneja@vmware.com>