### PR TITLE
Revert "Update base.yml to echo debian copyright file path"

### DIFF
--- a/tern/command_lib/base.yml
+++ b/tern/command_lib/base.yml
@@ -94,7 +94,7 @@ dpkg:
       1:
         container:
           - "pkgs=`dpkg --get-selections | cut -f1 -d':' | awk '{print $1}'`"
-          - "for p in $pkgs; do echo /usr/share/doc/$p/copyright; echo LICF; done"
+          - "for p in $pkgs; do cat /usr/share/doc/$p/copyright; echo LICF; done"
     delimiter: 'LICF'
   proj_urls: {}
 


### PR DESCRIPTION
`echo` actually does not work in this case as it only prints
out the path to the copyright file, not the copyright text.

This reverts commit 44ae4472eb07de47291afbae6381e68fa02a52c5.

Signed-off-by: mukultaneja <mtaneja@vmware.com>