### PR TITLE
Update base.yml to echo debian copyright file path

### DIFF
--- a/tern/command_lib/base.yml
+++ b/tern/command_lib/base.yml
@@ -94,7 +94,7 @@ dpkg:
       1:
         container:
           - "pkgs=`dpkg --get-selections | cut -f1 -d':' | awk '{print $1}'`"
-          - "for p in $pkgs; do cat /usr/share/doc/$p/copyright; echo LICF; done"
+          - "for p in $pkgs; do /bin/cat /usr/share/doc/$p/copyright; echo LICF; done"
     delimiter: 'LICF'
   proj_urls: {}
 


### PR DESCRIPTION
This PR does following,

1.It updates`dpkg` section inside `base.yml`
to use the absolute path of `cat` utility
to get copyright text.
2.It addresses issue#565 which is, 'not
able to find `cat` command location in
$PATH for CENTOS systems'.

Resolved: #565

Signed-off-by: mukultaneja <mtaneja@vmware.com>