### PR TITLE
Adding support for bundler

### DIFF
--- a/tern/command_lib/snippets.yml
+++ b/tern/command_lib/snippets.yml
@@ -96,3 +96,14 @@ gem:
       - 'check'
       - 'mirror'
   packages: 'gem'
+bundle:
+  install: 'install'
+  remove: 'remove'
+  ignore:
+      - 'update'
+      - 'config'
+      - 'add'
+      - 'init'
+      - 'package'
+      - 'exec'
+  packages: 'gem'


### PR DESCRIPTION
bundler is a package manager utility for gem package manager
to install packages listed in .gem files. Which is kind of
like installing from package.json file in node projects.
A snippet for bundle is added in snippets.yml which will invoke
the gem packages analyzer commands in base.yml.

This pr is extension of pr #663.

Signed-off-by: abhay <abhay.katheria1998@gmail.com>