### PR TITLE
Enable -r--/redo option for extensions

### DIFF
--- a/tern/analyze/docker/run.py
+++ b/tern/analyze/docker/run.py
@@ -64,7 +64,7 @@ def analyze(image_obj, args, dfile_lock=False, dfobj=None):
     '''Analyze the image object either using the default method or the extended
     method'''
     if not dfile_lock and args.extend:
-        run_extension(image_obj, args.extend)
+        run_extension(image_obj, args.extend, args.redo)
     else:
         analyze_docker_image(image_obj, args.redo, dfile_lock, dfobj)
 

--- a/tern/extensions/cve_bin_tool/executor.py
+++ b/tern/extensions/cve_bin_tool/executor.py
@@ -23,13 +23,13 @@ logger = logging.getLogger(constants.logger_name)
 
 class CveBinTool(Executor):
     '''Execute cve-bin-tool'''
-    def execute(self, image_obj):
+    def execute(self, image_obj, redo=False):
         '''Execution should be:
             cve-bin-tool -u now /path/to/directory
         '''
         command = 'cve-bin-tool -u now'
         # run the command against the image filesystems
-        if not passthrough.run_on_image(image_obj, command, True):
+        if not passthrough.run_on_image(image_obj, command, True, redo=redo):
             logger.error("cve-bin-tool error")
             sys.exit(1)
         # for now we just print the results for each layer

--- a/tern/extensions/executor.py
+++ b/tern/extensions/executor.py
@@ -10,7 +10,7 @@ from abc import abstractmethod
 class Executor(metaclass=ABCMeta):
     '''Base class for the external tool executor'''
     @abstractmethod
-    def execute(self, image_obj):
+    def execute(self, image_obj, redo=False):
         '''Return a string consisting of the command the tool should execute
         for the container image filesystem. Allow for the filesystem directory
         to be incorporated in the command'''

--- a/tern/extensions/scancode/executor.py
+++ b/tern/extensions/scancode/executor.py
@@ -114,14 +114,14 @@ def add_file_data(layer_obj, collected_files):
 
 class Scancode(Executor):
     '''Execute scancode'''
-    def execute(self, image_obj):
+    def execute(self, image_obj, redo=False):
         '''Execution should be:
             scancode -ilpcu --quiet --json - /path/to/directory
         '''
         for layer in image_obj.layers:
             # load the layers from cache
             common.load_from_cache(layer)
-            if not layer.files_analyzed:
+            if redo or not layer.files_analyzed:
                 # the layer doesn't have analyzed files, so run analysis
                 file_list = collect_layer_data(layer)
                 if file_list:


### PR DESCRIPTION
This PR does following,

1.It enables -r--/redo option for
extensions by passing `args.redo` argument
value to extension’s executor method.

Resolved: #653

Signed-off-by: mukultaneja <mtaneja@vmware.com>