### PR TITLE
Add Scancode header in generated documents

### DIFF
--- a/tern/analyze/common.py
+++ b/tern/analyze/common.py
@@ -52,6 +52,7 @@ def load_from_cache(layer, redo=False):
             layer.files_analyzed = cache.cache[layer.fs_hash]['files_analyzed']
             layer.os_guess = cache.cache[layer.fs_hash]['os_guess']
             layer.pkg_format = cache.cache[layer.fs_hash]['pkg_format']
+            layer.extension_info = cache.cache[layer.fs_hash]['extension_info']
         load_files_from_cache(layer)
     return loaded
 

--- a/tern/classes/image_layer.py
+++ b/tern/classes/image_layer.py
@@ -37,6 +37,8 @@ class ImageLayer:
         checksum
         checksum: the checksum
         checksums: a dictionary of the form {<checksum_type>: <checksum>}
+        extension_info: a dictionary contains extension info such as extension
+        header info{<headers>: <set_of_header_strings>}
     methods:
         add_package: adds a package to the layer
         remove_package: removes a package from the layer
@@ -69,6 +71,7 @@ class ImageLayer:
         self.__checksum_type = ''
         self.__checksum = ''
         self.__checksums = {}
+        self.__extension_info = {}
 
     @property
     def diff_id(self):
@@ -109,6 +112,14 @@ class ImageLayer:
     @property
     def checksums(self):
         return self.__checksums
+
+    @property
+    def extension_info(self):
+        return self.__extension_info
+
+    @extension_info.setter
+    def extension_info(self, extension_info):
+        self.__extension_info = extension_info
 
     @created_by.setter
     def created_by(self, create_string):
@@ -264,6 +275,8 @@ class ImageLayer:
             layer_dict.update({'files': file_list})
             # take care of the 'origins' property
             layer_dict.update({'origins': self.origins.to_dict()})
+            # take care of the 'extension_info' property
+            layer_dict.update({'extension_info': self.extension_info})
         return layer_dict
 
     def get_package_names(self):

--- a/tern/extensions/scancode/executor.py
+++ b/tern/extensions/scancode/executor.py
@@ -93,6 +93,10 @@ def collect_layer_data(layer_obj):
     else:
         # make FileData objects for each result
         data = json.loads(result)
+        notice = data.get("headers")[0].get("notice")
+        headers = layer_obj.extension_info.get("headers", set())
+        headers.add(notice)
+        layer_obj.extension_info["headers"] = headers
         for f in data['files']:
             if f['type'] == 'file' and f['size'] != 0:
                 files.append(get_scancode_file(f))

--- a/tern/formats/default/generator.py
+++ b/tern/formats/default/generator.py
@@ -25,16 +25,17 @@ def print_full_report(image):
     notes = ''
     for image_origin in image.origins.origins:
         notes = notes + content.print_notices(image_origin, '', '\t')
+
+    # collect extension's header per layer
+    headers = get_extension_headers(image.layers)
+    for header in headers:
+        notes = notes + header + '\n\n'
+
     for layer in image.layers:
         if layer.import_image:
             notes = notes + print_full_report(layer.import_image)
         else:
-            if len(layer.origins.origins) == 0:
-                notes += '\tLayer: {0}:\n'.format(layer.fs_hash[:10])
-            else:
-                for layer_origin in layer.origins.origins:
-                    notes = notes + content.print_notices(layer_origin,
-                                                          '\t', '\t\t')
+            notes = notes + get_layer_notices(layer)
             (layer_pkg_list, layer_license_list,
              file_level_licenses) = get_layer_info_list(layer)
             # Collect files + packages + licenses in the layer
@@ -46,6 +47,35 @@ def print_full_report(image):
                 layer_license_list) if layer_license_list else 'None')
             notes = notes + formats.package_demarkation
     return notes
+
+
+def get_layer_notices(layer):
+    '''
+    Given a image layer, collect all notices attached
+    to it.
+    '''
+    notices = ''
+    if len(layer.origins.origins) == 0:
+        notices = '\tLayer: {0}:\n'.format(layer.fs_hash[:10])
+    else:
+        for layer_origin in layer.origins.origins:
+            notices += content.print_notices(layer_origin, '\t', '\t\t')
+
+    return notices
+
+
+def get_extension_headers(layers):
+    '''
+    Given all image layers, collect header string set
+    by extension on each layer level.
+    '''
+    headers = set()
+    for layer in layers:
+        layer_headers = layer.extension_info.get("headers", set())
+        for layer_header in layer_headers:
+            headers.add(layer_header)
+
+    return headers
 
 
 def get_layer_info_list(layer):

--- a/tests/test_analyze_common.py
+++ b/tests/test_analyze_common.py
@@ -51,6 +51,7 @@ class TestAnalyzeCommon(unittest.TestCase):
                 'os_guess': 'Ubuntu',
                 'pkg_format': 'tar',
                 'files': [{'name': 'README.md', 'path': '/home/test/projectsX'}],
+                'extension_info': {},
                 'packages': [{'name': 'README'}]
             }}
         self.assertTrue(common.load_from_cache(self.image.layers[0], redo=False))

--- a/tests/test_class_image_layer.py
+++ b/tests/test_class_image_layer.py
@@ -136,6 +136,16 @@ class TestClassImageLayer(unittest.TestCase):
                          {'sha1': '12345abcde',
                           'md5': '1ff38cc592c4c5d0c8e3ca38be8f1eb1'})
 
+    def testSetExtensionInfo(self):
+        self.layer.extension_info = {"header": set({"Test Header"})}
+        self.assertIsInstance(self.layer.extension_info, dict)
+        self.assertIsNotNone(
+            self.layer.extension_info.get("header", None), None)
+        self.assertIsInstance(
+            self.layer.extension_info.get("header", None), set)
+        header = self.layer.extension_info.get("header").pop()
+        self.assertEqual(header, "Test Header")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR does following,

1.It adds scancode extension header into default
report format.
2. It adds a new property `extension_info` in
`ImageLayer` class to contain information such as
`header` generated from various extension.
3. It updates `print_full_report` function to
address `too-many-branches` build error.
4. It updates `test_analyze_common` to address
`extension_info` property change.
5. It adds a new test case in `test_class_image_layer`
to verify `extension_info` propery of ImageLayer
object.

Resolved: #643

Signed-off-by: mukultaneja <mtaneja@vmware.com>