### PR TITLE
Bug fix if image has no created_by key

### DIFF
--- a/tern/analyze/docker/helpers.py
+++ b/tern/analyze/docker/helpers.py
@@ -158,10 +158,12 @@ def get_commands_from_history(image_layer):
         image_layer.origins.add_notice_to_origins(origin_layer, Notice(
             formats.dockerfile_line.format(dockerfile_instruction=instruction),
             'info'))
+        command_line = instruction.split(' ', 1)[1]
     else:
+        instruction = ''
         image_layer.origins.add_notice_to_origins(origin_layer, Notice(
             formats.no_created_by, 'warning'))
-    command_line = instruction.split(' ', 1)[1]
+        command_line = instruction
     # Image layers are created with the directives RUN, ADD and COPY
     # For ADD and COPY instructions, there is no information about the
     # packages added


### PR DESCRIPTION
Currently, if you run Tern on a squashed Docker image, Tern fails to
execute because there is no created_by key to assign as the instruction.
This because the Docker squash feature removes the created_by key. This
error would also be seen on non-squashed images that for whatever reason
don't have a created_by key associated with a certain layer.

This commit makes a change in the get_commands_from_history() function
to set the instruction line as a blank string if no created_by key is
available.

Resolves #636

Signed-off-by: Rose Judge <rjudge@vmware.com>