### PR TITLE
Let GNU tar extract leading forwardslash members

### DIFF
--- a/tern/utils/rootfs.py
+++ b/tern/utils/rootfs.py
@@ -111,8 +111,12 @@ def check_tar_members(tar_file):
     the members of the tarfile or if it is empty'''
     result, error = shell_command(False, check_tar, tar_file)
     if error:
-        logger.error("Malformed tar: %s", error.decode())
-        raise EOFError("Malformed tarball: {}".format(tar_file))
+        error_msg = error.decode()
+        if "Removing leading" in error_msg:
+            pass
+        else:
+            logger.error("Malformed tar: %s", error_msg)
+            raise EOFError("Malformed tarball: {}".format(tar_file))
     if not result:
         raise ValueError("Empty tarball: {}".format(tar_file))
     return result


### PR DESCRIPTION
Currently, we use tar -t to test if tar can untar a given tarball
before we extract the tarball. This allows us to take advantage of
tar's testing of malformed or malicious tarballs. GNU tar will
remove leading forwardslashes in members if it finds any. This gets
piped to stderr with a message. We check if any error exists and
exit, despite the fact that in this case, GNU tar successfully
extracted the tarball while dealing with a possible security issue.

Hence in this change, we check to see if the error message is what
we would expect if GNU tar encounters the leading forwardslash. If
that is the error, we continue on.

Resolves #684

Signed-off-by: Nisha K <nishak@vmware.com>