### PR TITLE
extensions: scancode: Increase timeout limit

### DIFF
--- a/tern/extensions/scancode/executor.py
+++ b/tern/extensions/scancode/executor.py
@@ -81,7 +81,7 @@ def collect_layer_data(layer_obj):
     '''
     files = []
     # run scancode against a directory
-    command = 'scancode -ilpcu --quiet --json -'
+    command = 'scancode -ilpcu --quiet --timeout 300 --json -'
     full_cmd = get_filesystem_command(layer_obj, command)
     origin_layer = 'Layer: ' + layer_obj.fs_hash[:10]
     result, error = rootfs.shell_command(True, full_cmd)


### PR DESCRIPTION
Golang binaries take a large amount of time to scan by scancode.
The default timeout is at 120 seconds. Scancode reports an error
when it hits the timeout limit. In order to let scancode finish
scanning filesystems with large binaries, we increate the timeout
to 300 seconds which is 5 minutes.

Signed-off-by: Nisha K <nishak@vmware.com>