### PR TITLE
Get Debian package licenses from copyrights

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -12,3 +12,4 @@ requests
 stevedore
 pbr
 dockerfile-parse
+debut

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ dockerfile-parse~=0.0
 requests~=2.23
 stevedore>=1.32
 pbr>=5.4
+debut>=0.9

--- a/tern/analyze/common.py
+++ b/tern/analyze/common.py
@@ -23,6 +23,8 @@ from tern.utils import cache
 from tern.utils import constants
 from tern.utils import general
 from tern.utils import rootfs
+from debut import debcon
+from debut import copyright as debut_copyright
 
 # global logger
 logger = logging.getLogger(constants.logger_name)
@@ -217,7 +219,8 @@ def convert_to_pkg_dicts(pkg_dict):
                'version': 'versions',
                'pkg_license': 'licenses',
                'copyright': 'copyrights',
-               'proj_url': 'proj_urls'}
+               'proj_url': 'proj_urls',
+               'pkg_licenses': 'pkg_licenses'}
     pkg_list = []
     len_names = len(pkg_dict['names'])
     # make a list of keys that correspond with package property names
@@ -235,6 +238,44 @@ def convert_to_pkg_dicts(pkg_dict):
             a_pkg.update({key: value[index]})
         pkg_list.append(a_pkg)
     return pkg_list
+
+
+def get_licenses_from_deb_copyright(deb_copyright):
+    '''
+    Given the debian copyright text,
+    1. parse each copyright text
+    2. filter out all the available licenses
+    3. returns a list of unique licenses found inside
+    the copyright text
+    '''
+    collected_paragraphs = list()
+    pkg_licenses = set()
+    for paragraph in iter(debcon.get_paragraphs_data(deb_copyright)):
+        if 'license' in paragraph:
+            cp = debut_copyright.CopyrightLicenseParagraph.from_dict(paragraph)
+            collected_paragraphs.append(cp)
+
+    deb_pkg_data = debut_copyright.DebianCopyright(
+        collected_paragraphs).to_dict()
+    for paragraph in deb_pkg_data.get("paragraphs"):
+        pkg_license = paragraph.get("license")
+        if not pkg_license.startswith("*"):
+            pkg_license = pkg_license.split("\n")[0]
+            if pkg_license:
+                pkg_licenses.add(pkg_license)
+
+    return list(pkg_licenses)
+
+
+def get_deb_package_licenses(deb_copyrights):
+    '''
+    Given a list of debian copyrights for the same number of packages,
+    returns a list package licenses for each of the packages
+    '''
+    deb_licenses = list()
+    for deb_copyright in deb_copyrights:
+        deb_licenses.append(get_licenses_from_deb_copyright(deb_copyright))
+    return deb_licenses
 
 
 def add_base_packages(image_layer, binary, shell):
@@ -261,6 +302,11 @@ def add_base_packages(image_layer, binary, shell):
             origin_layer, Notice(snippet_msg, 'info'))
         # get all the packages in the base layer
         pkg_dict, invoke_msg, warnings = collate_list_metadata(shell, listing)
+
+        if listing.get("pkg_format") == "deb":
+            pkg_dict["pkg_licenses"] = get_deb_package_licenses(
+                pkg_dict["copyrights"])
+
         if invoke_msg:
             image_layer.origins.add_notice_to_origins(
                 origin_layer, Notice(invoke_msg, 'error'))

--- a/tern/classes/package.py
+++ b/tern/classes/package.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 from tern.classes.file_data import FileData
 from tern.classes.notice import Notice
@@ -20,6 +20,7 @@ class Package:
         origins: a list of NoticeOrigin objects
         checksum: checksum as package property
         files: list of files in a package
+        pkg_licenses: all licenses found within a package
 
     methods:
         to_dict: returns a dict representation of the instance
@@ -39,6 +40,7 @@ class Package:
         self.__checksum = ''
         self.__origins = Origins()
         self.__files = []
+        self.__pkg_licenses = []
 
     @property
     def name(self):
@@ -60,9 +62,17 @@ class Package:
     def pkg_license(self):
         return self.__pkg_license
 
+    @property
+    def pkg_licenses(self):
+        return self.__pkg_licenses
+
     @pkg_license.setter
     def pkg_license(self, pkg_license):
         self.__pkg_license = pkg_license
+
+    @pkg_licenses.setter
+    def pkg_licenses(self, pkg_licenses):
+        self.__pkg_licenses = pkg_licenses
 
     @property
     def copyright(self):

--- a/tests/test_class_package.py
+++ b/tests/test_class_package.py
@@ -21,6 +21,7 @@ class TestClassPackage(unittest.TestCase):
         self.p1.proj_url = 'github.com'
         self.p1.download_url = 'https://github.com'
         self.p1.checksum = '123abc456'
+        self.p1.pkg_licenses = ['MIT', 'GPL']
 
         self.p2 = Package('p2')
 
@@ -36,6 +37,7 @@ class TestClassPackage(unittest.TestCase):
         self.assertFalse(self.p2.copyright)
         self.assertFalse(self.p2.download_url)
         self.assertFalse(self.p2.checksum)
+        self.assertFalse(self.p2.pkg_licenses)
 
     def testSetters(self):
         self.assertRaises(AttributeError, setattr, self.p2, 'name', 'y')
@@ -51,6 +53,8 @@ class TestClassPackage(unittest.TestCase):
         self.assertEqual(self.p2.download_url, 'https://github.com')
         self.p2.checksum = '123abc456'
         self.assertEqual(self.p2.checksum, '123abc456')
+        self.p2.pkg_licenses = ['license1', 'license2']
+        self.assertEqual(self.p2.pkg_licenses, ['license1', 'license2'])
 
     def testGetters(self):
         self.assertEqual(self.p1.name, 'p1')
@@ -60,6 +64,7 @@ class TestClassPackage(unittest.TestCase):
         self.assertEqual(self.p1.proj_url, 'github.com')
         self.assertEqual(self.p1.download_url, 'https://github.com')
         self.assertEqual(self.p1.checksum, '123abc456')
+        self.assertEqual(self.p1.pkg_licenses, ['MIT', 'GPL'])
 
     def testAddFile(self):
         p1 = Package('package')
@@ -108,6 +113,7 @@ class TestClassPackage(unittest.TestCase):
         self.assertEqual(a_dict['checksum'], '123abc456')
         self.assertEqual(a_dict['files'][0]['name'], 'test.java')
         self.assertEqual(a_dict['files'][0]['path'], 'abc/pqr/test.java')
+        self.assertEqual(a_dict['pkg_licenses'], ['MIT', 'GPL'])
 
     def testToDictTemplate(self):
         template1 = TestTemplate1()
@@ -145,13 +151,15 @@ class TestClassPackage(unittest.TestCase):
         p_dict = {'name': 'p1',
                   'version': '1.0',
                   'pkg_license': 'Apache 2.0',
-                  'checksum': 'abcxyz'}
+                  'checksum': 'abcxyz',
+                  'pkg_licenses': ['MIT', 'GPL']}
         p = Package('p1')
         p.fill(p_dict)
         self.assertEqual(p.name, 'p1')
         self.assertEqual(p.version, '1.0')
         self.assertEqual(p.pkg_license, 'Apache 2.0')
         self.assertEqual(p.checksum, 'abcxyz')
+        self.assertEqual(p.pkg_licenses, ['MIT', 'GPL'])
         self.assertFalse(p.copyright)
         self.assertFalse(p.proj_url)
         self.assertEqual(len(p.origins.origins), 1)


### PR DESCRIPTION
This PR adds functionality to parse Debian style
copyright texts to get package level licenses.

Thanks to mukultaneja <mtaneja@vmware.com>
for their work.

Signed-off-by: Nisha K <nishak@vmware.com>