### PR TITLE
classes: Set digest when instantiating DockerImage

### DIFF
--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -66,7 +66,8 @@ test_suite = {
     ['python tests/test_class_package.py'],
     re.compile('tern/classes/template.py'):
     ['python tests/test_class_template.py',
-     'tern report -f spdxtagvalue -i photon:3.0'],
+     'tern report -f spdxtagvalue -i photon:3.0',
+     'tern lock Dockerfile'],
     # tern/command_lib
     re.compile('tern/command_lib'): [
         'tern report -i photon:3.0',

--- a/tests/test_class_docker_image.py
+++ b/tests/test_class_docker_image.py
@@ -70,15 +70,31 @@ class TestClassDockerImage(unittest.TestCase):
         self.assertEqual(self.image.repotag, 'vmware/tern@sha256:20b32a9a2'
                                              '0752aa1ad7582c667704fda9f004cc4'
                                              'bfd8601fac7f2656c7567bb4')
-        self.assertEqual(self.image.name, 'vmware/tern@sha256')
-        self.assertEqual(self.image.tag, '20b32a9a20752aa1ad7582c667704fda9f00'
-                                         '4cc4bfd8601fac7f2656c7567bb4')
+        self.assertEqual(self.image.name, 'vmware/tern')
+        self.assertEqual(self.image.tag, '')
+        self.assertTrue(self.image.checksum_type, 'sha256')
+        self.assertTrue(self.image.checksum, '20b32a9a20752aa1ad7582c66'
+                                             '7704fda9f004cc4bfd8601fac7'
+                                             'f2656c7567bb4')
         self.assertFalse(self.image.image_id)
         self.assertFalse(self.image.manifest)
         self.assertFalse(self.image.repotags)
         self.assertFalse(self.image.config)
         self.assertFalse(self.image.layers)
         self.assertFalse(self.image.history)
+        # test instantiating with a tag
+        if not check_image('vmware/tern:testimage'):
+            try:
+                container.pull_image('vmware/tern:testimage')
+            except subprocess.CalledProcessError as error:
+                print(error.output)
+
+        d = DockerImage('vmware/tern:testimage')
+        self.assertEqual(d.name, 'vmware/tern')
+        self.assertEqual(d.tag, 'testimage')
+        self.assertEqual(d.checksum_type, 'sha256')
+        self.assertEqual(d.checksum, '20b32a9a20752aa1ad7582c667704fda9f004cc4'
+                                     'bfd8601fac7f2656c7567bb4')
 
     def testLoadImage(self):
         self.image.load_image()


### PR DESCRIPTION
We can make use of the available functions to get the Docker image
digest and set the values for checksum_type and checksum when
instantiating a DockerImage class. This commit will parse the repotag
string to get the repository name and tag. If a tag was used, then
the image digest will also be set. It is assumed that either a tag
or an image digest will be used. The tests have been modified
accordingly.

Signed-off-by: Nisha K <nishak@vmware.com>