### PR TITLE
extensions: cve-bin-tool: Print error and result

### DIFF
--- a/tern/analyze/passthrough.py
+++ b/tern/analyze/passthrough.py
@@ -68,12 +68,24 @@ def execute_external_command(layer_obj, command, is_sudo=False):
     origin_layer = 'Layer: ' + layer_obj.fs_hash[:10]
     result, error = rootfs.shell_command(is_sudo, command)
     if error:
-        logger.error("Error in executing external command: %s", str(error))
+        msg = error.decode('utf-8')
+        logger.error("Error in executing external command: %s", msg)
         layer_obj.origins.add_notice_to_origins(origin_layer, Notice(
-            str(error), 'error'))
+            msg, 'error'))
         return False
-    layer_obj.analyzed_output = result.decode()
+    layer_obj.analyzed_output = result.decode('utf-8')
     return True
+
+
+def execute_and_pass(layer_obj, command, is_sudo=False):
+    '''Similar to execute_external_command, but the results and the errors
+    are stored together in layer_obj's analyzed_output property to be
+    post-processed. The result and error will be separated by two new line
+    characters \n\n'''
+    full_cmd = get_filesystem_command(layer_obj, command)
+    result, error = rootfs.shell_command(is_sudo, full_cmd)
+    layer_obj.analyzed_output = error.decode(
+        'utf-8') + '\n\n' + result.decode('utf-8')
 
 
 def run_on_image(image_obj, command, is_sudo=False, redo=False):

--- a/tern/extensions/cve_bin_tool/executor.py
+++ b/tern/extensions/cve_bin_tool/executor.py
@@ -11,7 +11,6 @@ The assumption is that cve-bin-tool is globally executable
 """
 
 import logging
-import sys
 
 from tern.analyze import passthrough
 from tern.extensions.executor import Executor
@@ -25,13 +24,12 @@ class CveBinTool(Executor):
     '''Execute cve-bin-tool'''
     def execute(self, image_obj, redo=False):
         '''Execution should be:
-            cve-bin-tool -u now /path/to/directory
+            cve-bin-tool -x -u now /path/to/directory
         '''
-        command = 'cve-bin-tool -u now'
-        # run the command against the image filesystems
-        if not passthrough.run_on_image(image_obj, command, True, redo=redo):
-            logger.error("cve-bin-tool error")
-            sys.exit(1)
-        # for now we just print the results for each layer
+        command = 'cve-bin-tool -x -u now'
         for layer in image_obj.layers:
+            # execute the command for each layer
+            logger.debug("Analyzing layer %s", layer.fs_hash[:10])
+            passthrough.execute_and_pass(layer, command, True)
+            # for now we just print the results for each layer
             print(layer.analyzed_output)


### PR DESCRIPTION
The cve-bin-tool script errors out if it finds any CVEs and pipes
the error to stderr which tern will catch and report dutifully.
However, erroring out due to found CVEs is an expected behaviour
for a tool used in an CI/CD pipeline to alert developers.

This commit brings in the following changes:
- Add a new convenience function in passthrough.py to just store
  the error message and the result separated by two newline characters.
- Decode error and result messages to utf-8 so it gets printed to
  stdout neatly.
- Modify the cve-bin-tool executor to call the execute_and_pass
  function for each layer in the image object and store the result
  and error in the analyzed_output property to be subsequently
  printed.

Resolves #689

Signed-off-by: Nisha K <nishak@vmware.com>