### PR TITLE
Update README with support Docker image info

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ $ tern report -i debian:buster -o output.txt
 
 *WARNING*: The CLI has changed since the last release. Visit [Tern's PyPI project page](https://pypi.org/project/tern/) to find the correct CLI options or just run `tern -h`.
 
-Tern creates a report containing the Bill of Materials (BoM) of a container image, including notes about how it collects this information, and files for which it has no information about. Currently, Tern supports only containers built using Docker. This is the most ubiquitous type of container image that exists so the project started with a focus on those. However, it is architected to support other images that closely follow the [OCI image spec](https://github.com/opencontainers/image-spec/blob/master/spec.md).
+Tern creates a report containing the Bill of Materials (BoM) of a container image, including notes about how it collects this information, and files for which it has no information about. Currently, Tern supports containers only built using Docker using image manifest version 2, schema 2. Docker image manifest version 2, schema 1 has been [deprecated](https://docs.docker.com/registry/spec/deprecated-schema-v1/) by Docker. Tern will support container images created using Docker version 19.03.0 or later. Docker is the most ubiquitous type of container image that exists so the project started with a focus on those. However, it is architected to support other images that closely follow the [OCI image spec](https://github.com/opencontainers/image-spec/blob/master/spec.md).
 
 ## Generating a BoM report for a Docker image<a name="bom-for-docker-image">
 If you have a Docker image pulled locally and want to inspect it


### PR DESCRIPTION
This commit updates Tern's README to include information about the types
of Docker images that Tern supports. Tern will not support Docker images
that contain deprecated image manifests schema versions.

Signed-off-by: Rose Judge <rjudge@vmware.com>