### PR TITLE
Adding zypper to analyze openSUSE images

### DIFF
--- a/tern/command_lib/snippets.yml
+++ b/tern/command_lib/snippets.yml
@@ -157,3 +157,14 @@ yarn:
     - 'add'
     - 'remove'
   packages: 'npm'
+
+zypper:
+  install:
+    - 'in'
+    - 'install'
+  remove:
+    - 'rm'
+    - 'remove'
+  ignore:
+    - 'clean'
+  packages: 'rpm'


### PR DESCRIPTION
This commit adds zypper package manager
in snippet.yml to analyze openSUSE
images

Resolved: #693

Signed-off-by: mukultaneja <mtaneja@vmware.com>