### PR TITLE
Allow for multiple snippet install and remove cmds

### DIFF
--- a/tern/command_lib/command_lib.py
+++ b/tern/command_lib/command_lib.py
@@ -128,14 +128,16 @@ def set_command_attrs(command_obj):
         # the command is in the library
         if 'install' in command_listing.keys():
             # try to move install to a subcommand
-            if command_obj.reassign_word(command_listing['install'],
-                                         'subcommand'):
-                command_obj.set_install()
+            for install_listing in command_listing['install']:
+                if command_obj.reassign_word(install_listing, 'subcommand'):
+                    command_obj.set_install()
+                    break
         if 'remove' in command_listing.keys():
             # try to move remove to a subcommand
-            if command_obj.reassign_word(command_listing['remove'],
-                                         'subcommand'):
-                command_obj.set_remove()
+            for remove_listing in command_listing['remove']:
+                if command_obj.reassign_word(remove_listing, 'subcommand'):
+                    command_obj.set_remove()
+                    break
         if 'ignore' in command_listing.keys():
             # check if any of the words in the ignore list are in
             # the list of command words

--- a/tern/command_lib/snippets.yml
+++ b/tern/command_lib/snippets.yml
@@ -7,115 +7,151 @@
 # image: the image name that the tool uses
 # tag: the image tag name that the tool uses
 apt-get:
-  install: 'install' # subcommand to install
-  remove: 'purge' # subcommand to remove a package
+  install:
+    - 'install' # subcommand to install
+  remove:
+    - 'purge' # subcommand to remove a package
   ignore: # list of subcommands that don't add or remove packages
     - 'update' 
   packages: 'dpkg' # refer to base.yml's method of collection
 
 tyum:
-  install: 'install'
-  remove: 'remove'
+  install:
+    - 'install'
+  remove:
+    - 'remove'
   ignore:
     - 'check-update'
     - 'clean'
   packages: 'tdnf'
 
 tdnf:
-  install: 'install'
-  remove: 'remove'
+  install:
+    - 'install'
+  remove:
+    - 'remove'
   ignore:
     - 'check-update'
     - 'clean'
   packages: 'tdnf'
 
 apk:
-  install: 'add'
-  remove: 'del'
+  install:
+    - 'add'
+  remove:
+    - 'del'
   packages: 'apk'
 
 pacman:
-  install: '-Syu'
-  remove: '-Rcs'
+  install:
+    - '-Syu'
+  remove:
+    - '-Rcs'
   packages: 'pacman'
 
 yum:
-  install: 'install'
-  remove: 'remove'
+  install:
+    - 'install'
+  remove:
+    - 'remove'
   ignore:
     - 'check-update'
     - 'clean'
   packages: 'rpm'
 
 dnf:
-  install: 'install'
-  remove: 'remove'
+  install:
+    - 'install'
+  remove:
+    - 'remove'
   ignore:
     - 'check-update'
     - 'clean'
   packages: 'rpm'
+
 rpm:
-   install: '-i'
-   remove: '-e'
-   packages: 'rpm'
+  install:
+    - '-i'
+    - '-U'
+  remove:
+    - '-e'
+  packages: 'rpm'
+
 pip:
-   install: 'install'
-   remove: 'uninstall'
-   ignore:
-     - 'freeze'
-     - 'list'
-     - 'download'
-     - 'show'
-     - 'check'
-     - 'config'
-     - 'hash'
-     - 'wheel'
-   packages: 'pip'
+  install:
+    - 'install'
+  remove:
+    - 'uninstall'
+  ignore:
+    - 'freeze'
+    - 'list'
+    - 'download'
+    - 'show'
+    - 'check'
+    - 'config'
+    - 'hash'
+    - 'wheel'
+  packages: 'pip'
+
 pip3:
-   install: 'install'
-   remove: 'uninstall'
-   ignore:
-     - 'freeze'
-     - 'list'
-     - 'download'
-     - 'show'
-     - 'check'
-     - 'config'
-     - 'hash'
-     - 'wheel'
-   packages: 'pip3'
+  install:
+    - 'install'
+  remove:
+    - 'uninstall'
+  ignore:
+    - 'freeze'
+    - 'list'
+    - 'download'
+    - 'show'
+    - 'check'
+    - 'config'
+    - 'hash'
+    - 'wheel'
+  packages: 'pip3'
+
 gem:
-  install: 'install'
-  remove: 'uninstall'
+  install:
+    - 'install'
+  remove:
+    - 'uninstall'
   ignore:
-      - 'fetch'
-      - 'build'
-      - 'lock'
-      - 'unpack'
-      - 'cleanup'
-      - 'check'
-      - 'mirror'
+    - 'fetch'
+    - 'build'
+    - 'lock'
+    - 'unpack'
+    - 'cleanup'
+    - 'check'
+    - 'mirror'
   packages: 'gem'
+
 bundle:
-  install: 'install'
-  remove: 'remove'
+  install:
+    - 'install'
+  remove:
+    - 'remove'
   ignore:
-      - 'update'
-      - 'config'
-      - 'add'
-      - 'init'
-      - 'package'
-      - 'exec'
+    - 'update'
+    - 'config'
+    - 'add'
+    - 'init'
+    - 'package'
+    - 'exec'
   packages: 'gem'
+
 npm:
-  install: 'install'
-  remove: 'uninstall'
+  install:
+    - 'install'
+  remove:
+    - 'uninstall'
   ignore:
     - 'ping'
   packages: 'npm'
+
 yarn:
-  install: 'install'
-  remove: 'uninstall'
+  install:
+    - 'install'
+  remove:
+    - 'uninstall'
   ignore:
     - 'publish'
     - 'add'


### PR DESCRIPTION
This commit makes two primary changes:

1) Adds functionality to `command_lib.py` that enables multiple entries
   for both install and remove directives in `snippets.yml`.

2) Updates `snippets.yml` to represent `install` and `remove` directives
   as a YAML list. Also, adjust spacing and new lines in some cases to
   make the YAML file more consistently formatted.

Resolves #715

Signed-off-by: Rose Judge <rjudge@vmware.com>