### PR TITLE
formats: spdxtagvalue: Fix 2.2 validation errors

### DIFF
--- a/tern/formats/spdx/formats.py
+++ b/tern/formats/spdx/formats.py
@@ -7,6 +7,7 @@
 SPDX document formatting
 """
 
+import hashlib
 import uuid
 
 # basic strings
@@ -42,3 +43,13 @@ extracted_text = 'ExtractedText: <text>Original license: {orig_license}</text>'
 def get_uuid():
     """ Return a UUID string"""
     return str(uuid.uuid4())
+
+
+def get_string_id(string):
+    """ Return a unique identifier for the given string"""
+    return hashlib.sha256(string.encode('utf-8')).hexdigest()[-7:]
+
+
+def get_license_ref(license_string):
+    """ For SPDX tag-value format, return a LicenseRef string """
+    return 'LicenseRef-' + get_string_id(license_string)

--- a/tern/formats/spdx/spdxtagvalue/image_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/image_helpers.py
@@ -56,7 +56,24 @@ def get_image_packages_license_block(image_obj):
                 licenses.add(package.pkg_license)
     for l in licenses:
         block += spdx_formats.license_id.format(
-            license_ref=phelpers.get_package_license_ref(l)) + '\n'
+            license_ref=spdx_formats.get_license_ref(l)) + '\n'
+        block += spdx_formats.extracted_text.format(orig_license=l) + '\n'
+    return block
+
+
+def get_image_file_license_block(image_obj):
+    '''Given the image object, get all the licenses found for the files
+    in the image. We will make use of some helper functions from the layer
+    and file helpers'''
+    block = ''
+    licenses = set()
+    for layer in image_obj.layers:
+        if layer.files_analyzed:
+            for l in lhelpers.get_layer_licenses(layer):
+                licenses.add(l)
+    for l in licenses:
+        block += spdx_formats.license_id.format(
+            license_ref=spdx_formats.get_license_ref(l)) + '\n'
         block += spdx_formats.extracted_text.format(orig_license=l) + '\n'
     return block
 
@@ -112,4 +129,6 @@ def get_image_block(image_obj, template):
         block += pkg_block + '\n'
         # print out the license block for packages
         block += get_image_packages_license_block(image_obj)
+    else:
+        block += get_image_file_license_block(image_obj)
     return block

--- a/tern/formats/spdx/spdxtagvalue/layer_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/layer_helpers.py
@@ -92,17 +92,19 @@ def get_layer_checksum(layer_obj):
     return '{}: {}'.format(layer_obj.checksum_type.upper(), layer_obj.checksum)
 
 
-def get_file_license_expressions(layer_obj):
-    '''Return a list of unique license expressions from the files analyzed
+def get_layer_licenses(layer_obj):
+    '''Return a list of unique licenses from the files analyzed
     in the layer object. It is assumed that the files were analyzed and
     there should be some license expressions. If there are not, an empty list
     is returned'''
-    license_expressions = set()
+    licenses = set()
     for filedata in layer_obj.files:
-        if filedata.license_expressions:
-            for le in filedata.license_expressions:
-                license_expressions.add(le)
-    return list(license_expressions)
+        # we will use the SPDX license expressions here as they will be
+        # valid SPDX license identifiers
+        if filedata.licenses:
+            for l in fhelpers.get_file_licenses(filedata):
+                licenses.add(l)
+    return list(licenses)
 
 
 def get_package_license_info_block(layer_obj):
@@ -111,10 +113,11 @@ def get_package_license_info_block(layer_obj):
     not analyzed'''
     block = ''
     if layer_obj.files_analyzed:
-        license_expressions = get_file_license_expressions(layer_obj)
-        if license_expressions:
-            for le in license_expressions:
-                block += 'PackageLicenseInfoFromFiles: {}\n'.format(le)
+        licenses = get_layer_licenses(layer_obj)
+        if licenses:
+            for l in licenses:
+                block += 'PackageLicenseInfoFromFiles: {}\n'.format(
+                    spdx_formats.get_license_ref(l))
         else:
             block = 'PackageLicenseInfoFromFiles: NONE\n'
     return block

--- a/tern/formats/spdx/spdxtagvalue/package_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/package_helpers.py
@@ -7,8 +7,6 @@
 Helper functions for packages in SPDX document
 """
 
-import hashlib
-
 from tern.formats.spdx import formats as spdx_formats
 from tern.report import content
 
@@ -31,13 +29,6 @@ def get_package_comment(package_obj):
                 notice_origin, '', '\t')
         return spdx_formats.package_comment.format(comment=comment)
     return comment
-
-
-def get_package_license_ref(package_license):
-    '''Return a LicenseRef with a unique SHA-256 ID for the package object
-    if it exists.'''
-    return 'LicenseRef-' + hashlib.sha256(package_license.encode(
-        'utf-8')).hexdigest()[-7:]
 
 
 def get_package_block(package_obj, template):
@@ -70,7 +61,7 @@ def get_package_block(package_obj, template):
     # Package License Declared (use the license ref for this)
     if mapping['PackageLicenseDeclared']:
         block += 'PackageLicenseDeclared: {}\n'.format(
-            get_package_license_ref(mapping['PackageLicenseDeclared']))
+            spdx_formats.get_license_ref(mapping['PackageLicenseDeclared']))
     else:
         block += 'PackageLicenseDeclared: NONE\n'
     # Package Copyright Text


### PR DESCRIPTION
This commit brings in two changes in order to produce valid SPDX 2.2
documents

The first change is to use the licenses at the file level instead of
license expressions. This is because the license expressions do not
necessarily match SPDX license identifiers. All references to licenses
within the document either need to be SPDX license identifiers or a
license reference string which would then be expanded at the end of
the document. This is the same way we manage the licenses reported
by the package managers i.e. each license string has a unique identifier
associated with it, which is used throughout the document and later
describing the actual license string collected. This method of listing
licenses is to avoid warnings with the SPDX validator tools.

In order to accomplish this, we add two generic helper functions in
formats.py which can be used by package_helpers.py and file_helpers.py
to make the license blocks of the document. We also add functions in
file_helpers.py and layer_helpers.py to collect unique licenses for
the FileData and ImageLayer objects. All this information is collected
in image_helpers.py when generating the license block for the whole
image object.

The second change is to use the SHA1 checksum of a file instead of
SHA256 as the SPDX 2.2 spec requires SHA1 to be the hashing algorithm
to calculate the package verification code.

Signed-off-by: Nisha K <nishak@vmware.com>