### PR TITLE
Don't set digest type for raw image tarballs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ jobs:
     steps:
       - setup
       - run: pip install bandit~=1.6 GitPython~=2.1
+      - run: docker pull photon:3.0 && docker save photon:3.0 > photon.tar
       - run: c=`python ci/evaluate_docs.py`; if [ -z $c ]; then echo "No .py files to lint"; else echo $c | xargs bandit; fi
   # linting for PR commit messages
   commit_check:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,6 +26,7 @@ jobs:
         if: always() # run even if above step fails
         run: |
           pip install bandit~=1.6
+          docker pull photon:3.0 && docker save photon:3.0 > photon.tar
           c=`python ci/evaluate_docs.py`; if [ -z $c ]; then echo "No .py files to lint"; else echo $c | xargs bandit; fi
       - name: Test Changes
         if: always() # run even if above step fails

--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -81,6 +81,7 @@ test_suite = {
         'python tests/test_analyze_common.py',
         'tern report -i golang:alpine',
         'tern report -d samples/alpine_python/Dockerfile',
+        'tern report -w photon.tar',
         'tern lock Dockerfile'],
     # tern/report
     re.compile('tern/report'): [
@@ -106,7 +107,8 @@ test_suite = {
     re.compile('tests/test_class_command.py'):
         ['python tests/test_class_command.py'],
     re.compile('tests/test_class_docker_image.py'):
-        ['python tests/test_class_docker_image.py'],
+        ['python tests/test_class_docker_image.py',
+         'tern report -w photon.tar'],
     re.compile('tests/test_class_file_data.py'):
         ['python tests/test_class_file_data.py'],
     re.compile('tests/test_class_image.py'):

--- a/tern/classes/docker_image.py
+++ b/tern/classes/docker_image.py
@@ -37,7 +37,7 @@ class DockerImage(Image):
             self._tag = repo_dict.get('tag')
             self.set_checksum(
                 repo_dict.get('digest_type'), repo_dict.get('digest'))
-            if not self.checksum:
+            if not self.checksum and general.check_tar(repotag) is False:
                 # if there is no checksum, get the digest type
                 docker_image = container.check_image(self.__repotag)
                 # this object could be representing an image built from


### PR DESCRIPTION
This commit resolves a regression that happens when Tern attempts to set
the checksum for Docker images that are given in raw form. If the image
provided is in raw image form, we cannot pull the digest of the image
and should skip setting the checksum (in this case, the checksum will
default to a blank string).

This commit also adds tests to our CI that will run Tern on a raw image
tarball so we can try to catch issues like this in the future.

Resolves #719

Signed-off-by: Rose Judge <rjudge@vmware.com>