### PR TITLE
formats: spdxtagvalue: Fix missing LicenseRef

### DIFF
--- a/tern/formats/spdx/spdxtagvalue/image_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/image_helpers.py
@@ -129,6 +129,5 @@ def get_image_block(image_obj, template):
         block += pkg_block + '\n'
         # print out the license block for packages
         block += get_image_packages_license_block(image_obj)
-    else:
-        block += get_image_file_license_block(image_obj)
+    block += get_image_file_license_block(image_obj)
     return block


### PR DESCRIPTION
When both package level licenses and file level licenses exist,
then all the license references must be listed at the end of
the SPDX tag-value document. The logic, however, prints file
level license references only if package level licenses don't
exist. This change fixes the logic to print file level licenses
regardless of package level licenses existing.

Signed-off-by: Nisha K <nishak@vmware.com>