### PR TITLE
Replace yaml file cache

### DIFF
--- a/tern/extensions/scancode/executor.py
+++ b/tern/extensions/scancode/executor.py
@@ -74,6 +74,16 @@ def get_scancode_file(file_dict):
     return fd
 
 
+def add_scancode_headers(layer_obj, headers):
+    '''Given a list of headers from scancode data, add unique headers to
+    the list of existing headers in the layer object'''
+    unique_notices = {header.get("notice") for header in headers}
+    layer_headers = layer_obj.extension_info.get("headers", list())
+    for lh in layer_headers:
+        unique_notices.add(lh)
+    layer_obj.extension_info["headers"] = list(unique_notices)
+
+
 def collect_layer_data(layer_obj):
     '''Use scancode to collect data from a layer filesystem. This function will
     create a FileData object for every file found. After scanning, it will
@@ -93,10 +103,7 @@ def collect_layer_data(layer_obj):
     else:
         # make FileData objects for each result
         data = json.loads(result)
-        notice = data.get("headers")[0].get("notice")
-        headers = layer_obj.extension_info.get("headers", set())
-        headers.add(notice)
-        layer_obj.extension_info["headers"] = headers
+        add_scancode_headers(layer_obj, data["headers"])
         for f in data['files']:
             if f['type'] == 'file' and f['size'] != 0:
                 files.append(get_scancode_file(f))

--- a/tern/utils/cache.py
+++ b/tern/utils/cache.py
@@ -17,7 +17,7 @@ It is organized in this way:
 """
 
 import os
-import yaml
+import json
 from tern.utils.constants import cache_file
 from tern.utils import rootfs
 
@@ -34,7 +34,7 @@ def load():
         return
 
     with open(os.path.join(rootfs.mount_dir, cache_file)) as f:
-        cache = yaml.safe_load(f)
+        cache = json.load(f)
 
 
 def get_packages(layer_hash):
@@ -79,7 +79,7 @@ def add_layer(layer_obj):
 def save():
     '''Save the cache to the cache file'''
     with open(os.path.join(rootfs.mount_dir, cache_file), 'w') as f:
-        yaml.dump(cache, f, default_flow_style=False)
+        json.dump(cache, f)
 
 
 def remove_layer(layer_hash):
@@ -96,4 +96,4 @@ def clear():
     global cache
     cache = {}
     with open(os.path.join(rootfs.mount_dir, cache_file), 'w') as f:
-        yaml.dump(cache, f, default_flow_style=False)
+        json.dump(cache, f)

--- a/tern/utils/constants.py
+++ b/tern/utils/constants.py
@@ -29,7 +29,7 @@ logfile = 'tern.log'
 # manifest file
 manifest_file = 'manifest.json'
 # cache file
-cache_file = 'cache.yml'
+cache_file = 'cache.json'
 # default shell
 shell = '/bin/sh'
 # path where resolv.conf lives


### PR DESCRIPTION
This PR fixes #627

The JSON parser is a great deal faster than the YAML parser.
In order to make use of it though, all set data structures in the
cache need to be replaced with list data structures. Only the
extension info headers are sets. The first commit changes
the set of headers to a list of headers for the scancode
executor, which is the only extension that is used to collect
file level data.

The second commit then does the replacing of the cache file and
the loading and saving operations to use the JSON format rather
than the YAML format.

Signed-off-by: Nisha K <nishak@vmware.com>