### PR TITLE
Generate report.txt when no output file specified

### DIFF
--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -152,7 +152,5 @@ def report_out(args, *images):
     report = generate_report(args, *images)
     if not report:
         logger.error("%s not a recognized plugin.", args.report_format)
-    elif args.output_file:
-        write_report(report, args)
     else:
-        print(report)
+        write_report(report, args)


### PR DESCRIPTION
Tern and its documentation tells users that if no output file is
specified, Tern will generate and populate a `report.txt` file. Due to how
the logic was structured in `report.py`, however, Tern was instead
printing the report output to the console and failing to generate a
`report.txt` file. This commit fixes the logic in report.py and generates
a default `report.txt` when no output file is specified.

Resolves #731

Signed-off-by: Rose Judge <rjudge@vmware.com>