### PR TITLE
Add HTML report format

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ tern.formats =
     spdxtagvalue = tern.formats.spdx.spdxtagvalue.generator:SpdxTagValue
     json = tern.formats.json.generator:JSON
     yaml = tern.formats.yaml.generator:YAML
+    html = tern.formats.html.generator:HTML
 tern.extensions =
     cve_bin_tool = tern.extensions.cve_bin_tool.executor:CveBinTool
     scancode = tern.extensions.scancode.executor:Scancode

--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -169,7 +169,7 @@ def main():
                                metavar='REPORT_FORMAT',
                                help="Format the report using one of the "
                                "available formats: "
-                               "spdxtagvalue, json, yaml")
+                               "spdxtagvalue, json, yaml, html")
     parser_report.add_argument('-o', '--output-file', default=None,
                                metavar='FILE',
                                help="Write the report to a file. "

--- a/tern/formats/default/generator.py
+++ b/tern/formats/default/generator.py
@@ -98,7 +98,7 @@ def get_layer_info_list(layer):
         if pkg not in layer_pkg_list and pkg:
             layer_pkg_list.append(pkg)
 
-        package_licenses = get_package_licenses(package)
+        package_licenses = content.get_package_licenses(package)
         for package_license in package_licenses:
             if package_license not in layer_license_list:
                 layer_license_list.append(package_license)
@@ -106,56 +106,9 @@ def get_layer_info_list(layer):
     return layer_pkg_list, layer_license_list, file_level_licenses
 
 
-def get_package_licenses(package):
-    '''Given a package collect complete list of package licenses'''
-    pkg_licenses = set()
-    if package.pkg_license:
-        pkg_licenses.add(package.pkg_license)
-
-    if package.pkg_licenses:
-        for pkg_license in package.pkg_licenses:
-            if pkg_license:
-                pkg_licenses.add(pkg_license)
-
-    return list(pkg_licenses)
-
-
-def get_layer_packages_licenses(layer):
-    '''Given a image layer collect complete list of package licenses'''
-    pkg_licenses = set()
-    for package in layer.packages:
-        package_licenses = get_package_licenses(package)
-        for package_license in package_licenses:
-            pkg_licenses.add(package_license)
-
-    return list(pkg_licenses)
-
-
-def get_layer_files_licenses(layer):
-    '''Given a image layer collect complete list of file licenses'''
-    file_level_licenses = set()
-    for f in layer.files:
-        for license_expression in f.license_expressions:
-            if license_expression:
-                file_level_licenses.add(license_expression)
-
-    return list(file_level_licenses)
-
-
 def print_licenses_only(image_obj_list):
     '''Print a complete list of licenses for all images'''
-    full_licenses = set()
-    for image in image_obj_list:
-        for layer in image.layers:
-            pkg_licenses = get_layer_packages_licenses(layer)
-            for pkg_license in pkg_licenses:
-                full_licenses.add(pkg_license)
-
-            file_level_licenses = get_layer_files_licenses(layer)
-            for file_level_license in file_level_licenses:
-                full_licenses.add(file_level_license)
-
-    full_license_list = list(full_licenses)
+    full_license_list = content.get_licenses_only(image_obj_list)
     # Collect the full list of licenses from all the layers
     licenses = formats.full_licenses_list.format(list=", ".join(
         full_license_list) if full_license_list else 'None')

--- a/tern/formats/html/__init__.py
+++ b/tern/formats/html/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause

--- a/tern/formats/html/generator.py
+++ b/tern/formats/html/generator.py
@@ -1,0 +1,300 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+HTML document generator
+"""
+
+import logging
+
+from tern.formats import generator
+from tern.report.content import get_tool_version, get_licenses_only
+from tern.utils import constants
+
+
+# global logger
+logger = logging.getLogger(constants.logger_name)
+
+
+css = '''
+<style>
+ul, #myUL {
+  list-style-type: none;
+}
+li {
+    padding-top: 5px;padding-bottom: 5px;
+}
+#myUL {
+  margin: 0;
+  padding: 0;
+}
+.caret {
+  cursor: pointer;
+  user-select: none;
+  font-family: 'Inconsolata', monospace;
+}
+.caret::before {
+  content: " \\25B6";
+  color: ;
+  display: inline-block;
+margin-right: 6px;
+}
+.caret-down::before {
+  transform: rotate(90deg);
+}
+.nested {
+  display: none;
+}
+.active {
+  display: block;
+}
+.header {
+  text-align: left;
+  background: #f1f1f1;
+}
+.text-c {
+    color:green;
+    font-family:'Inconsolata',monospace;
+}
+.text-h {
+    font-family:'Inconsolata',monospace;
+}
+</style>\n
+'''
+
+
+js = '''
+<script>
+var toggler = document.getElementsByClassName("caret");
+var i;
+for (i = 0; i < toggler.length; i++) {
+  toggler[i].addEventListener("click", function() {
+    this.parentElement.querySelector(".nested").classList.toggle("active");
+    this.classList.toggle("caret-down");
+  });
+}
+</script>\n
+'''
+
+
+head = """
+<!DOCTYPE html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="https://fonts.googleapis.com/css2?family=Inconsolata:wght@300&family=Oswald&display=swap"
+rel="stylesheet"><link href="https://fonts.googleapis.com/css2?family=Josefin+Sans:ital,wght@1,300&display=swap"
+rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inconsolata&display=swap" rel="stylesheet">
+%s \n
+</head>
+<body>
+<div class="header">
+<img src="https://raw.githubusercontent.com/tern-tools/tern/master/docs/img/tern_logo.png" height="60px">\n
+<br>
+</div>\n
+<div style="font-family: \'Inconsolata\', monospace;">
+<p>
+Tern at %s
+<p>
+The following report was generated for "%s" image.
+</div>
+"""
+
+
+def image_handler(list_obj, indent):
+    '''Write html code for the images list in the report with
+    image name as title'''
+    html_string = ''
+    for i in list_obj:
+        html_string = html_string + dict_handler(i, indent+1)
+    return html_string
+
+
+def manifest_handler(list_obj, indent):
+    '''Write html code for the manifests list in the report
+    with config as title'''
+    html_string = '  '*indent + '<ul class ="nested"> \n'
+    for l in list_obj:
+        html_string = html_string + '  '*indent + '<li><span class="caret">' \
+            + str(l["Config"][:10]) + ' : ' + '</span> \n '
+        html_string = html_string + dict_handler(l, indent+1)
+        html_string = html_string + '  '*indent + '</li> \n'
+    html_string = html_string + '  '*indent + '</ul> \n'
+    return html_string
+
+
+def layers_handler(list_obj, indent):
+    '''Write html code for the origins list in the report
+    with tar_file hash as title'''
+    html_string = '  '*indent + '<ul class ="nested"> \n'
+    for l in list_obj:
+        html_string = html_string + '  '*indent + '<li><span class="caret">' \
+            + str(l["tar_file"][:10]) + ' : ' + '</span> \n '
+        html_string = html_string + dict_handler(l, indent+1)
+        html_string = html_string + '  '*indent + '</li> \n'
+    html_string = html_string + '  '*indent + '</ul> \n'
+    return html_string
+
+
+def history_handler(list_obj, indent):
+    '''Write html code for the history list in the report
+    with time-stamp as title'''
+    html_string = '  '*indent + '<ul class ="nested"> \n'
+    for l in list_obj:
+        html_string = html_string + '  '*indent + '<li><span class="caret">' \
+            + str(l["created"][:19]) + ' : ' + '</span> \n '
+        html_string = html_string + dict_handler(l, indent+1)
+        html_string = html_string + '  '*indent + '</li> \n'
+    html_string = html_string + '  '*indent + '</ul> \n'
+    return html_string
+
+
+def origins_handler(list_obj, indent):
+    '''Write html code for the origins list in the report
+    with origin string as title'''
+    html_string = '  '*indent + '<ul class ="nested"> \n'
+    for l in list_obj:
+        html_string = html_string + '  '*indent + '<li><span class="caret">' \
+            + str(l["origin_str"]) + '</span> \n '
+        html_string = html_string + dict_handler(l, indent+1)
+        html_string = html_string + '  '*indent + '</li> \n'
+    html_string = html_string + '  '*indent + '</ul> \n'
+    return html_string
+
+
+def list_handler(list_obj, indent):
+    '''Write html code for lists in report dictionary'''
+    html_string = ''
+    for i, _ in enumerate(list_obj):
+        if isinstance(list_obj[i], dict):
+            if "name" in list_obj[i].keys():
+                html_string = html_string + '  '*indent + \
+                    '<li><span class="caret">' + str(list_obj[i]["name"]) + \
+                    ' : ' + '</span> \n '
+            else:
+                html_string = html_string + '  '*indent + \
+                    '<li><span class="caret">' + str(i) + ' : ' + '</span> \n '
+            html_string = html_string + dict_handler(list_obj[i], indent+1)
+            html_string = html_string + '  '*indent + '</li> \n '
+        elif isinstance(list_obj[i], list):
+            html_string = html_string + '  '*indent + \
+                '<li><span class="caret">' + str(i) + ' : ' + '</span> \n '
+            html_string = html_string + '  '*indent + \
+                '<ul class ="nested"> \n '
+            html_string = html_string + list_handler(list_obj[i], indent+1)
+            html_string = html_string + '  '*indent + '</ul> \n ' + \
+                '  '*indent + '</li>\n '
+        else:
+            html_string = html_string + ' '*indent + '<li>' + \
+                '<span class="text-c">' + str(list_obj[i]) + \
+                '</span>\n</li> \n '
+    return html_string
+
+
+# pylint: disable=too-many-branches
+def dict_handler(dict_obj, indent):
+    '''Writes html code for dictionary in report dictionary'''
+    html_string = ''
+    html_string = html_string + '  '*indent + '<ul class ="nested"> \n'
+    for k, v in dict_obj.items():
+        if isinstance(v, dict):
+            if "name" in v.keys():
+                html_string = html_string + '  '*indent + \
+                    '<li><span class="caret">' + str(v["name"]) + ' : ' + \
+                    '</span> \n '
+            else:
+                html_string = html_string + '  '*indent + \
+                    '<li><span class="caret">' + str(k) + ' : ' + '</span> \n '
+            html_string = html_string + dict_handler(v, indent+1) + \
+                '  '*indent + '</li> \n '
+        elif isinstance(v, list):
+            html_string = html_string + '  '*indent + \
+                '<li><span class="caret">' + str(k) + ' : ' + \
+                '[%d]' % (len(v)) + '</span> \n '
+            if k == "images":
+                html_string = html_string + image_handler(v, indent) + \
+                    '  '*indent + '</li>\n'
+            elif k == "manifest":
+                html_string = html_string + manifest_handler(v, indent) + \
+                    '  '*indent + '</li>\n'
+            elif k == "layers":
+                html_string = html_string + layers_handler(v, indent) + \
+                    '  '*indent + '</li>\n'
+            elif k == "origins":
+                html_string = html_string + origins_handler(v, indent) + \
+                    '  '*indent + '</li>\n'
+            elif k == "history":
+                html_string = html_string + history_handler(v, indent) + \
+                    '  '*indent + '</li>\n'
+            else:
+                html_string = html_string + '  '*indent + \
+                    '<ul class ="nested"> \n ' + list_handler(v, indent+1) + \
+                    '  '*indent + '</ul> \n ' + '  '*indent + '</li> \n '
+        else:
+            html_string = html_string + ' '*indent + \
+                '<li><span class="text-h">' + str(k) + ' : ' + \
+                '</span><span class="text-c">' + str(v) + '</span></li>\n'
+    html_string = html_string + '  '*indent + '</ul> \n '
+    return html_string
+
+
+def report_dict_to_html(dict_obj):
+    '''Writes html code for report'''
+    html_string = ''
+    html_string = html_string + '<ul class ="myUL"> \n'
+    html_string = html_string + \
+        '<li><span class="caret">REPORT DETAILS</span> \n'
+    html_string = html_string + dict_handler(dict_obj, 0)
+    html_string = html_string + '</li></ul> \n'
+    return html_string
+
+
+def write_licenses(image_obj_list):
+    '''Adds licenses to top of the page'''
+    licenses = get_licenses_only(image_obj_list)
+    html_string = ''
+    html_string = html_string + '<ul class ="myUL"> \n'
+    html_string = html_string + '<li><span class="caret">Summary of \
+        Licenses Found</span> \n'
+    html_string = html_string + '<ul class ="nested"> \n'
+    for l in licenses:
+        html_string = html_string + \
+            '<li style="font-family: \'Inconsolata\' , monospace;" >' + \
+            l + '</li>\n'
+    html_string = html_string + '</ul></li></ul> \n'
+    return html_string
+
+
+def create_html_report(report_dict, image_obj_list):
+    '''Return the html report as a string'''
+    logger.debug("Creating HTML report...")
+    report = ''
+    report = report + '\n' + head % (css, get_tool_version(),
+                                     report_dict['images'][0]['image']['name']
+                                     + ':' +
+                                     report_dict['images'][0]['image']['tag'])
+    report = report + '\n' + write_licenses(image_obj_list)
+    report = report + '\n' + report_dict_to_html(report_dict)
+    report = report + '\n' + js
+    report = report + '\n' + '</body>\n</html>\n'
+    return report
+
+
+def get_report_dict(image_obj_list):
+    '''Given an image object list, return a python dict of the report'''
+    image_list = []
+    for image in image_obj_list:
+        image_list.append({'image': image.to_dict()})
+    image_dict = {'images': image_list}
+    return image_dict
+
+
+class HTML(generator.Generate):
+    def generate(self, image_obj_list):
+        '''Given a list of image objects, create a html report
+        for the images'''
+        report_dict = get_report_dict(image_obj_list)
+        report = create_html_report(report_dict, image_obj_list)
+        return report

--- a/tern/report/content.py
+++ b/tern/report/content.py
@@ -12,6 +12,54 @@ from tern.report import formats
 from tern.utils.general import get_git_rev_or_version
 
 
+def get_layer_packages_licenses(layer):
+    '''Given a image layer collect complete list of package licenses'''
+    pkg_licenses = set()
+    for package in layer.packages:
+        package_licenses = get_package_licenses(package)
+        for package_license in package_licenses:
+            pkg_licenses.add(package_license)
+    return list(pkg_licenses)
+
+
+def get_layer_files_licenses(layer):
+    '''Given a image layer collect complete list of file licenses'''
+    file_level_licenses = set()
+    for f in layer.files:
+        for license_expression in f.license_expressions:
+            if license_expression:
+                file_level_licenses.add(license_expression)
+    return list(file_level_licenses)
+
+
+def get_licenses_only(image_obj_list):
+    '''Returns a list of all the lists found in images'''
+    full_licenses = set()
+    for image in image_obj_list:
+        for layer in image.layers:
+            pkg_licenses = get_layer_packages_licenses(layer)
+            for pkg_license in pkg_licenses:
+                full_licenses.add(pkg_license)
+
+            file_level_licenses = get_layer_files_licenses(layer)
+            for file_level_license in file_level_licenses:
+                full_licenses.add(file_level_license)
+    return list(full_licenses)
+
+
+def get_package_licenses(package):
+    '''Given a package collect complete list of package licenses'''
+    pkg_licenses = set()
+    if package.pkg_license:
+        pkg_licenses.add(package.pkg_license)
+
+    if package.pkg_licenses:
+        for pkg_license in package.pkg_licenses:
+            if pkg_license:
+                pkg_licenses.add(pkg_license)
+    return list(pkg_licenses)
+
+
 def get_tool_version():
     '''Return a string describing the version and where it came from'''
     ver_type, ver = get_git_rev_or_version()

--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -35,6 +35,8 @@ def write_report(report, args):
     '''Write the report to a file'''
     if args.output_file:
         file_name = args.output_file
+    elif args.report_format == 'html':
+        file_name = constants.html_file
     else:
         file_name = constants.report_file
     with open(file_name, 'w') as f:

--- a/tern/utils/constants.py
+++ b/tern/utils/constants.py
@@ -47,5 +47,7 @@ workdir = 'workdir'
 mergedir = 'mergedir'
 # report file
 report_file = 'report.txt'
+# html report file
+html_file = 'report.html'
 # locked dockerfile
 locked_dockerfile = 'Dockerfile.lock'


### PR DESCRIPTION
This PR adds an HTML format to tern. Now users can
generate an html tree view for their tern reports.
using -f html command line option.

In report/content.py a new function get_license_only
was added to get the license summary from an image list.
This function is now used by default and html format
generator functions.