### PR TITLE
Use container image layer index

### DIFF
--- a/tern/analyze/common.py
+++ b/tern/analyze/common.py
@@ -288,7 +288,7 @@ def add_base_packages(image_layer, binary, shell):
         1. get the listing from the base.yml
         2. Invoke any commands against the base layer
         3. Make a list of packages and add them to the layer'''
-    origin_layer = 'Layer: ' + image_layer.fs_hash[:10]
+    origin_layer = 'Layer {}'.format(image_layer.layer_index)
     if image_layer.created_by:
         image_layer.origins.add_notice_to_origins(origin_layer, Notice(
             formats.layer_created_by.format(created_by=image_layer.created_by),
@@ -493,7 +493,7 @@ def add_snippet_packages(image_layer, command, pkg_listing, shell):
         4. For each unique package name, find the metadata and add to the
         layer'''
     # set up a notice origin for the layer
-    origin_layer = 'Layer: ' + image_layer.fs_hash[:10]
+    origin_layer = 'Layer {}'.format(image_layer.layer_index)
     # find packages for the command
     cmd_msg = formats.invoke_for_snippets + '\n' + \
         content.print_package_invoke(command.name)
@@ -554,7 +554,7 @@ def get_os_style(image_layer, binary):
     might be based off of given the pkg_format + package manager. If the binary
     provided does not exist in base.yml, add a warning notice'''
     origin_command_lib = formats.invoking_base_commands
-    origin_layer = 'Layer: ' + image_layer.fs_hash[:10]
+    origin_layer = 'Layer {}'.format(image_layer.layer_index)
     pkg_format = command_lib.check_pkg_format(binary)
     os_guess = command_lib.check_os_guess(binary)
     os_release = get_os_release(image_layer)

--- a/tern/analyze/docker/analyze.py
+++ b/tern/analyze/docker/analyze.py
@@ -61,7 +61,7 @@ def abort_analysis():
 
 def analyze_first_layer(image_obj, master_list, redo):
     # set up a notice origin for the first layer
-    origin_first_layer = 'Layer: ' + image_obj.layers[0].fs_hash[:10]
+    origin_first_layer = 'Layer {}'.format(image_obj.layers[0].layer_index)
     # find the shell from the first layer
     shell = common.get_shell(image_obj.layers[0])
     if not shell:
@@ -166,7 +166,7 @@ def analyze_subsequent_layers(image_obj, shell, master_list, redo, dfobj=None,  
 def image_setup(image_obj):
     '''Add notices for each layer'''
     for layer in image_obj.layers:
-        origin_str = 'Layer: ' + layer.fs_hash[:10]
+        origin_str = 'Layer {}'.format(layer.layer_index)
         layer.origins.add_notice_origin(origin_str)
         if layer.import_str:
             layer.origins.add_notice_to_origins(origin_str, Notice(

--- a/tern/analyze/docker/helpers.py
+++ b/tern/analyze/docker/helpers.py
@@ -152,7 +152,7 @@ def get_commands_from_history(image_layer):
     '''Given the image layer object and the shell, get the list of command
     objects that created the layer'''
     # set up notice origin for the layer
-    origin_layer = 'Layer: ' + image_layer.fs_hash[:10]
+    origin_layer = 'Layer {}'.format(image_layer.layer_index)
     if image_layer.created_by:
         instruction = created_to_instruction(image_layer.created_by)
         image_layer.origins.add_notice_to_origins(origin_layer, Notice(

--- a/tern/analyze/passthrough.py
+++ b/tern/analyze/passthrough.py
@@ -65,7 +65,7 @@ def execute_external_command(layer_obj, command, is_sudo=False):
     '''Given an Imagelayer object and a command in the form of a list, execute
     the command and store the results in the ImageLayer object either as
     results or as a Notice object'''
-    origin_layer = 'Layer: ' + layer_obj.fs_hash[:10]
+    origin_layer = 'Layer {}'.format(layer_obj.layer_index)
     result, error = rootfs.shell_command(is_sudo, command)
     if error:
         msg = error.decode('utf-8')

--- a/tern/classes/docker_image.py
+++ b/tern/classes/docker_image.py
@@ -173,10 +173,13 @@ class DockerImage(Image):
             layer_paths = self.get_image_layers(self._manifest)
             layer_diffs = self.get_diff_ids(self._config)
             checksum_type = self.get_diff_checksum_type(self._config)
+            layer_count = 1
             while layer_diffs and layer_paths:
                 layer = ImageLayer(layer_diffs.pop(0), layer_paths.pop(0))
                 layer.set_checksum(checksum_type, layer.diff_id)
                 layer.gen_fs_hash()
+                layer.layer_index = layer_count
+                layer_count = layer_count + 1
                 self._layers.append(layer)
             self.set_layer_created_by()
         except NameError:  # pylint: disable=try-except-raise

--- a/tern/classes/image_layer.py
+++ b/tern/classes/image_layer.py
@@ -29,6 +29,8 @@ class ImageLayer:
         Based on how container image layers are created, this is usually the
         last layer of the image that was imported
         import_str: The string from a build tool (like a Dockerfile) that
+        layer_index: The index position of the layer in relationship to the
+        other layers in the image. The base OS would be layer 1.
         created this layer by importing it from another image
         files_analyzed: whether the files in this layer are analyzed or not
         analyzed_output: the result of the file analysis
@@ -64,6 +66,7 @@ class ImageLayer:
         self.__origins = Origins()
         self.__import_image = None
         self.__import_str = ''
+        self.__layer_index = ''
         self.__pkg_format = ''
         self.__os_guess = ''
         self.__files_analyzed = False
@@ -140,6 +143,14 @@ class ImageLayer:
     @import_str.setter
     def import_str(self, import_str):
         self.__import_str = import_str
+
+    @property
+    def layer_index(self):
+        return self.__layer_index
+
+    @layer_index.setter
+    def layer_index(self, layer_index):
+        self.__layer_index = layer_index
 
     @property
     def pkg_format(self):

--- a/tern/extensions/cve_bin_tool/executor.py
+++ b/tern/extensions/cve_bin_tool/executor.py
@@ -29,7 +29,7 @@ class CveBinTool(Executor):
         command = 'cve-bin-tool -x -u now'
         for layer in image_obj.layers:
             # execute the command for each layer
-            logger.debug("Analyzing layer %s", layer.fs_hash[:10])
+            logger.debug("Analyzing layer %s", layer.layer_index)
             passthrough.execute_and_pass(layer, command, True)
             # for now we just print the results for each layer
             print(layer.analyzed_output)

--- a/tern/extensions/scancode/executor.py
+++ b/tern/extensions/scancode/executor.py
@@ -93,7 +93,7 @@ def collect_layer_data(layer_obj):
     # run scancode against a directory
     command = 'scancode -ilpcu --quiet --timeout 300 --json -'
     full_cmd = get_filesystem_command(layer_obj, command)
-    origin_layer = 'Layer: ' + layer_obj.fs_hash[:10]
+    origin_layer = 'Layer {}'.format(layer_obj.layer_index)
     result, error = rootfs.shell_command(True, full_cmd)
     if not result:
         logger.error(

--- a/tern/formats/default/generator.py
+++ b/tern/formats/default/generator.py
@@ -56,7 +56,7 @@ def get_layer_notices(layer):
     '''
     notices = ''
     if len(layer.origins.origins) == 0:
-        notices = '\tLayer: {0}:\n'.format(layer.fs_hash[:10])
+        notices = '\tLayer {0}:\n'.format(layer.layer_index)
     else:
         for layer_origin in layer.origins.origins:
             notices += content.print_notices(layer_origin, '\t', '\t\t')


### PR DESCRIPTION
Tern's logging and reporting checksum information is useful in
identifying layers in a container image. However, the current checksums
do not match the checksums in the image manifest. Instead of using the
Tern-calculated filesystem hash, use the layer index. To do
this, introduce a new property in the image_layer class called
layer_index. Set the layer_index for each layer in the load_image()
function in docker_image.py. Lastly, replace the calls to
layer.fs_hash[:10] with the new layer_index property.


Resolves #608

Signed-off-by: Rose Judge <rjudge@vmware.com>