### PR TITLE
Find installed software from shell script

### DIFF
--- a/tern/utils/general.py
+++ b/tern/utils/general.py
@@ -8,6 +8,7 @@ import random
 import re
 import regex
 import tarfile
+import shlex
 import subprocess  # nosec
 from contextlib import contextmanager
 from pathlib import Path
@@ -264,8 +265,8 @@ def parse_shell_variables_and_command(concatenated_command):
                                      'value': match_res.group(4)}
         statement['content'] = concatenated_command
     else:
-        # use clean_command() to clean tab and line indentations
-        statement['command'] = clean_command(concatenated_command)
+        # use shlex to clean tab, line indentations and long whitespaces.
+        statement['command'] = ' '.join(shlex.split(concatenated_command))
     return statement
 
 


### PR DESCRIPTION
This commit add a function find_installed_pkg_from_shell_script()
in tern/analyze/common.py which will filter the install commands
from the statements and find the installed software name.

Work towards #743.
Signed-off-by: WangJL <hazard15020@gmail.com>