### PR TITLE
Add CI test for HTML format

### DIFF
--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -89,7 +89,8 @@ test_suite = {
         'tern report -f yaml -i photon:3.0',
         'tern report -f json -i photon:3.0',
         'tern report -f spdxtagvalue -i photon:3.0',
-        'tern report -d samples/alpine_python/Dockerfile'],
+        'tern report -d samples/alpine_python/Dockerfile',
+        'tern report -f html -i photon:3.0'],
     # tern/formats/spdx
     re.compile('tern/formats/spdx'): [
         'tern report -f spdxtagvalue -i photon:3.0'],


### PR DESCRIPTION
Tern recently got a new html format. This commit
adds ci test to run whenever files under tern/report
are changed.

Signed-off-by: abhay <abhay.katheria1998@gmail.com>