### PR TITLE
Removing multiple options to instantiate Image class

### DIFF
--- a/tern/classes/image.py
+++ b/tern/classes/image.py
@@ -26,9 +26,9 @@ class Image:
         add_checksums: add new checksums in the existing list of the checksums
         to_dict: return a python dictionary representation of the image
     '''
-    def __init__(self, image_id=None):
-        '''Either initialize using id'''
-        self._image_id = image_id
+    def __init__(self, repotag=None):
+        '''Initialize using the image's repo name and tag string'''
+        self._repotag = repotag
         self._name = ''
         self._tag = ''
         self._manifest = {}
@@ -44,8 +44,8 @@ class Image:
         return self._manifest
 
     @property
-    def image_id(self):
-        return self._image_id
+    def repotag(self):
+        return self._repotag
 
     @property
     def config(self):
@@ -174,7 +174,7 @@ class Image:
         '''Some reports like SPDX want a unique name for the full image
         and this is currently not supported by any image tool. So using
         a combination of image id, name and tag instead'''
-        name = self.image_id[:10]
+        name = self.repotag[:10]
         if self.name:
             name = name + '-{}'.format(self.name)
         if self.tag:

--- a/tests/test_class_docker_image.py
+++ b/tests/test_class_docker_image.py
@@ -34,8 +34,6 @@ class TestClassDockerImage(unittest.TestCase):
                                  'a9a20752aa1ad7582c667704fda9f00'
                                  '4cc4bfd8601fac7f2656c7567bb4')
         # constants for this image
-        self.image_id = ('acb194ad84d0f9734e794fbbdbb65fb'
-                         '7db6eda83f33e9e817bcc75b1bdd99f5e')
         self.layer = ('c1c3a87012e7ff5791b31e94515b661'
                       'cdf06f6d5dc2f9a6245eda8774d257a13')
         self.no_layers = 1
@@ -76,7 +74,6 @@ class TestClassDockerImage(unittest.TestCase):
         self.assertTrue(self.image.checksum, '20b32a9a20752aa1ad7582c66'
                                              '7704fda9f004cc4bfd8601fac7'
                                              'f2656c7567bb4')
-        self.assertFalse(self.image.image_id)
         self.assertFalse(self.image.manifest)
         self.assertFalse(self.image.repotags)
         self.assertFalse(self.image.config)
@@ -98,15 +95,11 @@ class TestClassDockerImage(unittest.TestCase):
 
     def testLoadImage(self):
         self.image.load_image()
-        self.assertEqual(self.image.image_id, self.image_id)
         self.assertEqual(self.image.layers[0].diff_id, self.layer)
         self.assertEqual(len(self.image.layers), self.no_layers)
         self.assertEqual(self.image.layers[0].created_by, self.created_by)
         self.assertEqual(self.image.layers[0].checksum_type, 'sha256')
         self.assertEqual(self.image.layers[0].checksum, self.layer)
-
-    def testGetImageOption(self):
-        self.assertEqual(self.image.get_image_option(), self.image.repotag)
 
     def testGetLayerDiffIds(self):
         self.image.load_image()

--- a/tests/test_class_image.py
+++ b/tests/test_class_image.py
@@ -26,7 +26,7 @@ class TestClassImage(unittest.TestCase):
         del self.image3
 
     def testInstance(self):
-        self.assertEqual(self.image1.image_id, '1234abcd')
+        self.assertEqual(self.image1.repotag, '1234abcd')
         self.assertFalse(self.image1.name)
         self.assertFalse(self.image1.manifest)
         self.assertFalse(self.image1.tag)
@@ -35,7 +35,7 @@ class TestClassImage(unittest.TestCase):
         self.assertIsInstance(self.image1.origins, Origins)
 
     def testLoadImage(self):
-        self.assertEqual(self.image2.image_id, '5678efgh')
+        self.assertEqual(self.image2.repotag, '5678efgh')
         self.assertFalse(self.image2.layers)
         self.assertFalse(self.image2.name)
         self.assertFalse(self.image2.tag)
@@ -57,7 +57,7 @@ class TestClassImage(unittest.TestCase):
     def testToDict(self):
         self.image2.load_image()
         a_dict = self.image2.to_dict()
-        self.assertEqual(a_dict['image_id'], '5678efgh')
+        self.assertEqual(a_dict['repotag'], '5678efgh')
         self.assertEqual(len(a_dict['layers']), 1)
         self.assertEqual(len(a_dict['layers'][0]['packages']), 2)
 
@@ -68,7 +68,7 @@ class TestClassImage(unittest.TestCase):
         dict1 = self.image2.to_dict(template1)
         dict2 = self.image2.to_dict(template2)
         self.assertEqual(len(dict1.keys()), 2)
-        self.assertEqual(dict1['image.id'], '5678efgh')
+        self.assertEqual(dict1['image.repotag'], '5678efgh')
         self.assertEqual(len(dict1['image.layers']), 1)
         self.assertEqual(len(dict2.keys()), 3)
         self.assertFalse(dict2['notes'])

--- a/tests/test_class_template.py
+++ b/tests/test_class_template.py
@@ -35,7 +35,7 @@ class TestClassTemplate(unittest.TestCase):
 
     def testImage(self):
         mapping = self.template1.image()
-        self.assertEqual(mapping['image_id'], 'image.id')
+        self.assertEqual(mapping['repotag'], 'image.repotag')
         self.assertEqual(mapping['layers'], 'image.layers')
 
     def testNotice(self):

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -46,7 +46,7 @@ class TestTemplate1(Template):
                 'files': 'layer.files'}
 
     def image(self):
-        return {'image_id': 'image.id',
+        return {'repotag': 'image.repotag',
                 'layers': 'image.layers'}
 
 
@@ -80,7 +80,7 @@ class TestTemplate2(Template):
         return mapping
 
     def image(self):
-        mapping = {'image_id': 'image.id',
+        mapping = {'repotag': 'image.repotag',
                    'layers': 'image.layers'}
         # we update the mapping with another defined mapping
         mapping.update(self.origins())


### PR DESCRIPTION
This commit does following,
1. Modifies the Image class to be instantiated
with a generic repotag property
2. Removes the ImageID property
3. Modifies the tests appropriately

Resolved: #747

Signed-off-by: mukultaneja <mtaneja@vmware.com>