### PR TITLE
Remove raise immediately statements

### DIFF
--- a/tern/analyze/docker/container.py
+++ b/tern/analyze/docker/container.py
@@ -179,8 +179,8 @@ def extract_image_metadata(image_tag_string):
             os.remove(placeholder)
         if not os.listdir(temp_path):
             raise IOError('Unable to untar Docker image')
-    except docker.errors.APIError:  # pylint: disable=try-except-raise
-        raise
+    except docker.errors.APIError as e:
+        raise docker.errors.APIError(e)
 
 
 def close_client():

--- a/tern/classes/docker_image.py
+++ b/tern/classes/docker_image.py
@@ -182,9 +182,10 @@ class DockerImage(Image):
                 layer_count = layer_count + 1
                 self._layers.append(layer)
             self.set_layer_created_by()
-        except NameError:  # pylint: disable=try-except-raise
-            raise
-        except subprocess.CalledProcessError:  # pylint: disable=try-except-raise
-            raise
-        except IOError:  # pylint: disable=try-except-raise
-            raise
+        except NameError as e:
+            raise NameError(e)
+        except subprocess.CalledProcessError as e:
+            raise subprocess.CalledProcessError(
+                e.returncode, cmd=e.cmd, output=e.output, stderr=e.stderr)
+        except IOError as e:
+            raise IOError(e)

--- a/tern/utils/rootfs.py
+++ b/tern/utils/rootfs.py
@@ -74,7 +74,7 @@ def root_command(command, *extra):
     if error:
         logger.error("Command failed. %s", error.decode())
         raise subprocess.CalledProcessError(  # nosec
-            1, cmd=full_cmd, output=error)
+            1, cmd=full_cmd, output=None, stderr=error.decode())
     return result
 
 
@@ -296,5 +296,6 @@ def calc_fs_hash(fs_path):
         with open(hash_file, 'w') as f:
             f.write(hash_contents.decode('utf-8'))
         return file_name
-    except subprocess.CalledProcessError:  # pylint: disable=try-except-raise
-        raise
+    except subprocess.CalledProcessError as e:
+        raise subprocess.CalledProcessError(  # nosec
+            1, cmd=e.cmd, output=e.output, stderr=e.stderr)


### PR DESCRIPTION
This commit removes raise only statements in try-except branches
found by pylint. Although the purpose was to re-raise the same
exception, it makes sense to be explicit about it. The change
basically replaces the empty raises with an explicit raising of
the same exception that the try branch brakes on.

Fixes #201

Signed-off-by: Nisha K <nishak@vmware.com>