### PR TITLE
Enable golang package listing

### DIFF
--- a/tern/command_lib/base.yml
+++ b/tern/command_lib/base.yml
@@ -379,3 +379,35 @@ npm:
           - "pkgs=`npm list -g | sed 's/\\(^[^a-z]*\\)\\([_.a-z0-9-]*\\)\\(@.*\\)/\\2/g' | grep -v '/usr*' | uniq`"
           - "for p in $pkgs; do npm view $p repository.url; done"
     delimiter: "\n"
+# golang----------------------------------------------------------------------
+go:
+  pkg_format: ''
+  os_guess:
+    - 'None'
+  path:
+    - 'usr/local/go/bin'
+  names:
+    invoke:
+      1:  
+        container:
+          - "go list -m all | tail -n +2 | cut -d ' ' -f 1" 
+    delimiter: "\n"
+  versions:
+    invoke:
+      1:
+        container:
+          - "go list -m all | tail -n +2 | cut -d ' ' -f 2"
+    delimiter: "\n"
+  copyrights:
+    invoke:
+      1:
+        container:
+          - "dirs=`go list -m -f={{{{.Dir}}}} all | tail -n+2`"
+          - "for d in $dirs; do find $d -type f -iname 'License' -o -iname 'license.txt' -o -iname 'license.md' | xargs cat; echo LICF; done"
+    delimiter: "LICF"
+  proj_urls:
+    invoke:
+      1:
+        container:
+          - "go list -m all | tail -n +2 | cut -d ' ' -f 1"
+    delimiter: "\n"

--- a/tern/command_lib/snippets.yml
+++ b/tern/command_lib/snippets.yml
@@ -178,3 +178,13 @@ microdnf:
     - 'check-update'
     - 'clean'
   packages: 'rpm'
+
+go:
+  install:
+    - 'build'
+    - 'mod'
+  remove:
+    - 'remove'
+  ignore:
+    - 'clean'
+  packages: 'go'


### PR DESCRIPTION
This commit adds commands in snippets.yml and base.yml to
to capture golang module name, version, proj_url and copyright
metadata in the output report. This commit does not currently
collect license information for golang modules as more advanced
parsing is required but functionality for this will come in
the future.

Work towards #695

Signed-off-by: abhaykatheria <abhay.katheria1998@gmail.com>