### PR TITLE
Bump up prospector and bandit versions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,7 @@ jobs:
           pip install .
       - name: Prospector Linting
         run: |
-          pip install prospector>=1.1
+          pip install prospector>=1.3
           prospector
   Commit_Message_Linting:
     runs-on: ubuntu-latest
@@ -49,7 +49,7 @@ jobs:
           pip install .
       - name: Security Linting
         run: |
-          pip install bandit~=1.6
+          pip install bandit>=1.6
           c=`python ci/evaluate_docs.py`; if [ -z $c ]; then echo "No .py files to lint"; else echo $c | xargs bandit; fi
   Test_Changes:
     runs-on: ubuntu-latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,4 +55,4 @@ console_scripts =
     tern = tern.__main__:main
 
 [options.extras_require]
-dev = bandit~=1.6; prospector>=1.2; GitPython~=2.1; tox>=3.14
+dev = bandit>=1.6; prospector>=1.3; GitPython~=2.1; tox>=3.14

--- a/tern/analyze/common.py
+++ b/tern/analyze/common.py
@@ -186,8 +186,8 @@ def get_os_release(base_layer):
         lines = f.readlines()
     pretty_name = ''
     # iterate through os-release file to find OS
-    for l in lines:
-        key, val = l.rstrip().split('=', 1)
+    for line in lines:
+        key, val = line.rstrip().split('=', 1)
         if key == "PRETTY_NAME":
             pretty_name = val
             break

--- a/tern/extensions/scancode/executor.py
+++ b/tern/extensions/scancode/executor.py
@@ -58,7 +58,7 @@ def get_scancode_file(file_dict):
     fd.short_file_type = get_file_type(file_dict)
     fd.add_checksums({'sha1': file_dict['sha1'], 'md5': file_dict['md5']})
     if file_dict['licenses']:
-        fd.licenses = [l['short_name'] for l in file_dict['licenses']]
+        fd.licenses = [li['short_name'] for li in file_dict['licenses']]
     fd.license_expressions = file_dict['license_expressions']
     if file_dict['copyrights']:
         fd.copyrights = [c['value'] for c in file_dict['copyrights']]

--- a/tern/formats/html/generator.py
+++ b/tern/formats/html/generator.py
@@ -116,10 +116,10 @@ def manifest_handler(list_obj, indent):
     '''Write html code for the manifests list in the report
     with config as title'''
     html_string = '  '*indent + '<ul class ="nested"> \n'
-    for l in list_obj:
+    for lo in list_obj:
         html_string = html_string + '  '*indent + '<li><span class="caret">' \
-            + str(l["Config"][:10]) + ' : ' + '</span> \n '
-        html_string = html_string + dict_handler(l, indent+1)
+            + str(lo["Config"][:10]) + ' : ' + '</span> \n '
+        html_string = html_string + dict_handler(lo, indent+1)
         html_string = html_string + '  '*indent + '</li> \n'
     html_string = html_string + '  '*indent + '</ul> \n'
     return html_string
@@ -129,10 +129,10 @@ def layers_handler(list_obj, indent):
     '''Write html code for the origins list in the report
     with tar_file hash as title'''
     html_string = '  '*indent + '<ul class ="nested"> \n'
-    for l in list_obj:
+    for lo in list_obj:
         html_string = html_string + '  '*indent + '<li><span class="caret">' \
-            + str(l["tar_file"][:10]) + ' : ' + '</span> \n '
-        html_string = html_string + dict_handler(l, indent+1)
+            + str(lo["tar_file"][:10]) + ' : ' + '</span> \n '
+        html_string = html_string + dict_handler(lo, indent+1)
         html_string = html_string + '  '*indent + '</li> \n'
     html_string = html_string + '  '*indent + '</ul> \n'
     return html_string
@@ -142,10 +142,10 @@ def history_handler(list_obj, indent):
     '''Write html code for the history list in the report
     with time-stamp as title'''
     html_string = '  '*indent + '<ul class ="nested"> \n'
-    for l in list_obj:
+    for lo in list_obj:
         html_string = html_string + '  '*indent + '<li><span class="caret">' \
-            + str(l["created"][:19]) + ' : ' + '</span> \n '
-        html_string = html_string + dict_handler(l, indent+1)
+            + str(lo["created"][:19]) + ' : ' + '</span> \n '
+        html_string = html_string + dict_handler(lo, indent+1)
         html_string = html_string + '  '*indent + '</li> \n'
     html_string = html_string + '  '*indent + '</ul> \n'
     return html_string
@@ -155,10 +155,10 @@ def origins_handler(list_obj, indent):
     '''Write html code for the origins list in the report
     with origin string as title'''
     html_string = '  '*indent + '<ul class ="nested"> \n'
-    for l in list_obj:
+    for lo in list_obj:
         html_string = html_string + '  '*indent + '<li><span class="caret">' \
-            + str(l["origin_str"]) + '</span> \n '
-        html_string = html_string + dict_handler(l, indent+1)
+            + str(lo["origin_str"]) + '</span> \n '
+        html_string = html_string + dict_handler(lo, indent+1)
         html_string = html_string + '  '*indent + '</li> \n'
     html_string = html_string + '  '*indent + '</ul> \n'
     return html_string
@@ -259,10 +259,10 @@ def write_licenses(image_obj_list):
     html_string = html_string + '<li><span class="caret">Summary of \
         Licenses Found</span> \n'
     html_string = html_string + '<ul class ="nested"> \n'
-    for l in licenses:
+    for lic in licenses:
         html_string = html_string + \
             '<li style="font-family: \'Inconsolata\' , monospace;" >' + \
-            l + '</li>\n'
+            lic + '</li>\n'
     html_string = html_string + '</ul></li></ul> \n'
     return html_string
 

--- a/tern/formats/spdx/spdxtagvalue/file_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/file_helpers.py
@@ -65,9 +65,9 @@ def get_license_info_block(filedata):
     if not filedata.licenses:
         block = 'LicenseInfoInFile: NONE\n'
     else:
-        for l in get_file_licenses(filedata):
+        for lic in get_file_licenses(filedata):
             block = block + 'LicenseInfoInFile: {}'.format(
-                spdx_formats.get_license_ref(l)) + '\n'
+                spdx_formats.get_license_ref(lic)) + '\n'
     return block
 
 

--- a/tern/formats/spdx/spdxtagvalue/image_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/image_helpers.py
@@ -54,10 +54,10 @@ def get_image_packages_license_block(image_obj):
         for package in layer.packages:
             if package.pkg_license:
                 licenses.add(package.pkg_license)
-    for l in licenses:
+    for lic in licenses:
         block += spdx_formats.license_id.format(
-            license_ref=spdx_formats.get_license_ref(l)) + '\n'
-        block += spdx_formats.extracted_text.format(orig_license=l) + '\n'
+            license_ref=spdx_formats.get_license_ref(lic)) + '\n'
+        block += spdx_formats.extracted_text.format(orig_license=lic) + '\n'
     return block
 
 
@@ -69,12 +69,12 @@ def get_image_file_license_block(image_obj):
     licenses = set()
     for layer in image_obj.layers:
         if layer.files_analyzed:
-            for l in lhelpers.get_layer_licenses(layer):
-                licenses.add(l)
-    for l in licenses:
+            for lic in lhelpers.get_layer_licenses(layer):
+                licenses.add(lic)
+    for lic in licenses:
         block += spdx_formats.license_id.format(
-            license_ref=spdx_formats.get_license_ref(l)) + '\n'
-        block += spdx_formats.extracted_text.format(orig_license=l) + '\n'
+            license_ref=spdx_formats.get_license_ref(lic)) + '\n'
+        block += spdx_formats.extracted_text.format(orig_license=lic) + '\n'
     return block
 
 

--- a/tern/formats/spdx/spdxtagvalue/layer_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/layer_helpers.py
@@ -102,8 +102,8 @@ def get_layer_licenses(layer_obj):
         # we will use the SPDX license expressions here as they will be
         # valid SPDX license identifiers
         if filedata.licenses:
-            for l in fhelpers.get_file_licenses(filedata):
-                licenses.add(l)
+            for lic in fhelpers.get_file_licenses(filedata):
+                licenses.add(lic)
     return list(licenses)
 
 
@@ -115,9 +115,9 @@ def get_package_license_info_block(layer_obj):
     if layer_obj.files_analyzed:
         licenses = get_layer_licenses(layer_obj)
         if licenses:
-            for l in licenses:
+            for lic in licenses:
                 block += 'PackageLicenseInfoFromFiles: {}\n'.format(
-                    spdx_formats.get_license_ref(l))
+                    spdx_formats.get_license_ref(lic))
         else:
             block = 'PackageLicenseInfoFromFiles: NONE\n'
     return block


### PR DESCRIPTION
Prospector version 1.3 catches PEP8 error E741 which catches letters
that look like numbers like l, I and O. As a result of bumping up
the version, a number of E741 errors were exposed. Fixing those errors
as well. Bandit also has an updated version. No errors were found
with Bandit.

Signed-off-by: Nisha K <nishak@vmware.com>