### PR TITLE
Fix package version collection for Alpine

### DIFF
--- a/tern/command_lib/base.yml
+++ b/tern/command_lib/base.yml
@@ -120,7 +120,7 @@ apk:
         container:
           # use double quotes when using awk
           - "pkgs=`apk info 2>/dev/null`"
-          - "for p in $pkgs; do apk info $p 2>/dev/null | head -1 | awk '{print $1}'; done"
+          - "for p in $pkgs; do lic=`apk info $p 2>/dev/null | head -1 | awk '{print $1}'`; echo $lic | awk -F \"${p}-\" '{print $2}'; done"
     delimiter: "\n"
   licenses:
     invoke:


### PR DESCRIPTION
The apk command to collect version information for Alpine packages was
collecting the package name and version instead of just the isolated
version string. This was causing Tern's output file to report the
package as pkgname-pkgname-version. This commit fixes the version
command under the apk package manager section in base.yml to only
collect the package version information.

Resolves #758

Signed-off-by: Rose Judge <rjudge@vmware.com>