### PR TITLE
Add support to execute commands from WORKDIR

### DIFF
--- a/tern/analyze/docker/analyze.py
+++ b/tern/analyze/docker/analyze.py
@@ -106,7 +106,12 @@ def analyze_subsequent_layers(image_obj, shell, master_list, redo, dfobj=None,  
                               dfile_lock=False):
     # get packages for subsequent layers
     curr_layer = 1
+    work_dir = None
     while curr_layer < len(image_obj.layers):  # pylint:disable=too-many-nested-blocks
+        # If workdir changes, update value accordingly
+        # so we can later execute base.yml commands from the workdir.
+        if image_obj.layers[curr_layer].get_layer_workdir() is not None:
+            work_dir = image_obj.layers[curr_layer].get_layer_workdir()
         # if there is no shell, try to see if it exists in the current layer
         if not shell:
             shell = common.get_shell(image_obj.layers[curr_layer])
@@ -126,7 +131,7 @@ def analyze_subsequent_layers(image_obj, shell, master_list, redo, dfobj=None,  
                 if isinstance(pkg_listing, str):
                     try:
                         common.add_base_packages(
-                            image_obj.layers[curr_layer], pkg_listing, shell)
+                            image_obj.layers[curr_layer], pkg_listing, shell, work_dir)
                     except KeyboardInterrupt:
                         logger.critical(errors.keyboard_interrupt)
                         abort_analysis()
@@ -134,7 +139,7 @@ def analyze_subsequent_layers(image_obj, shell, master_list, redo, dfobj=None,  
                     try:
                         common.add_snippet_packages(
                             image_obj.layers[curr_layer], command, pkg_listing,
-                            shell)
+                            shell, work_dir)
                     except KeyboardInterrupt:
                         logger.critical(errors.keyboard_interrupt)
                         abort_analysis()

--- a/tern/classes/image_layer.py
+++ b/tern/classes/image_layer.py
@@ -327,3 +327,10 @@ class ImageLayer:
                 file_data.set_checksum('sha256', attrs_tuple[2])
                 file_data.extattrs = attrs_tuple[0]
                 self.add_file(file_data)
+
+    def get_layer_workdir(self):
+        # If the layer is created by a WORKDIR command then return the workdir
+        match = re.search(r"\bWORKDIR\ (\/\w+)+\b", self.created_by)
+        if match:
+            return match.group().split()[1]
+        return None

--- a/tern/command_lib/command_lib.py
+++ b/tern/command_lib/command_lib.py
@@ -205,7 +205,7 @@ def invoke_in_rootfs(snippet_list, shell, package=''):
         raise
 
 
-def get_pkg_attr_list(shell, attr_dict, package_name='', chroot=True,
+def get_pkg_attr_list(shell, attr_dict, work_dir, package_name='', chroot=True,  # pylint:disable=too-many-arguments
                       override=''):
     '''The command library has package attributes listed like this:
         {invoke: {1: {container: [command1, command2]},
@@ -225,6 +225,9 @@ def get_pkg_attr_list(shell, attr_dict, package_name='', chroot=True,
             if 'container' in attr_dict['invoke'][step].keys():
                 snippet_list = attr_dict['invoke'][step]['container']
                 result = ''
+                # If work_dir exist cd into it
+                if work_dir is not None:
+                    snippet_list.insert(0, 'cd ' + work_dir)
                 # if we need to run in a chroot environment
                 if chroot:
                     try:

--- a/tern/tools/verify_invoke.py
+++ b/tern/tools/verify_invoke.py
@@ -28,6 +28,15 @@ def look_up_lib(keys):
     return subd
 
 
+def get_workdir(image_obj):
+    # get the workdir from the image config where the commands will be executed
+    config = image_obj.get_image_config(image_obj.get_image_manifest())
+    workdir = config['config']['WorkingDir']
+    if workdir == '':
+        return None
+    return workdir
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='''
@@ -78,8 +87,9 @@ if __name__ == '__main__':
             info_dict = look_up_lib(args.keys)
         # try to invoke the commands
         try:
+            work_dir = get_workdir(image_obj)
             result = command_lib.get_pkg_attr_list(
-                args.shell, info_dict, args.package)
+                args.shell, info_dict, work_dir, args.package)
             print('Output list: ' + ' '.join(result[0]))
             print('Error messages: ' + result[1])
             print('Number of elements: ' + str(len(result[0])))


### PR DESCRIPTION
Currently tern does not track workdir while executing
base. This becomes very necessary while inspecting golang
images because the scripts for collecting metadata for
go modules rely on the files present in workdir.

This PR adds functionality to execute the scripts in the
workdir in which they need to be executed. It is achieved
by looking for workdir in each layer. If their is no
workdir then the commands are executed in previous layers
workdir.

A function is added in classes/docker_image.py to get the
final workdir. It is utilised by verify_invoke script.

A function is added in classes/image_layer.py to return
current layers workdir.

In analyze/docker/analyze.py changes are made to collect
workdir which then passes through a series of fucntion
to reach command_lib.py get_package_attr_list(). Where
cd workdir command is added to snippet_list.

Resolves #766 

Signed-off-by: Abhay Katheria <abhay.katheria1998@gmail.com>