### PR TITLE
Enable Tern to run in a container for non-Linux host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,13 @@
-# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-FROM photon:3.0
+FROM debian:buster
 
-# install system dependencies
-# photon:3.0 comes with toybox which conflicts with some dependencies needed for tern to work, so uninstalling
-# toybox first
-RUN tdnf remove -y toybox && tdnf install -y tar findutils attr util-linux python3 python3-pip python3-setuptools git && pip3 install --upgrade pip && pip3 install tern
+# Install fuse-overlayfs and Tern dependencies
+RUN apt-get update && apt-get -y install wget gnupg2 tar findutils attr util-linux python3 python3-pip python3-setuptools git && pip3 install --upgrade pip && pip3 install tern && echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_10/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list && wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/Debian_10/Release.key -O Release.key && apt-key add - < Release.key && apt-get update -qq && apt-get -qq -y install buildah fuse-overlayfs && rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
-# make a mounting directory
-RUN mkdir hostmount
+# Adjust storage.conf to enable Fuse storage.
+RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' /etc/containers/storage.conf
 
-ENTRYPOINT ["tern", "-q", "-b", "/hostmount"]
+ENTRYPOINT ["tern", "--driver", "fuse"]
 CMD ["-h"]

--- a/README.md
+++ b/README.md
@@ -108,25 +108,34 @@ Build the Docker image (called `ternd` here). You may need to use sudo:
 $ docker build -t ternd .
 ```
 
+**NOTE**: By default, Tern will run with logging turned on. If you would like to silent the terminal output when running the ternd container, make the following change to the Dockerfile ENTRYPOINT before building:
+
+```
+--- a/Dockerfile
++++ b/Dockerfile
+-ENTRYPOINT ["tern", "--driver", "fuse"]
++ENTRYPOINT ["tern", "-q", "--driver", "fuse"]
+```
+
 Run the script `docker_run.sh`. You may need to use sudo. In the below command `debian` is the docker hub container image name  and `buster` is the tag that identifies the version we are interested in analyzing.
 
 ```
-$ ./docker_run.sh workdir ternd "report -i debian:buster" > output.txt
+$ ./docker_run.sh ternd "report -i debian:buster" > output.txt
 ```
 
 To produce a json report run
 ```
-$ ./docker_run.sh workdir ternd "report -f json -i debian:buster"
+$ ./docker_run.sh ternd "report -f json -i debian:buster"
 ```
 
-What the `docker_run.sh` script does is create the directory `workdir` if not present in your current working directory and run the built container as privileged with `workdir` bind mounted to it.
+What the `docker_run.sh` script does is run the built container as privileged.
 
 *WARNING:* privileged Docker containers are not secure. DO NOT run this container in production unless you have secured the node (VM or bare metal machine) that the docker daemon is running on.
 
 Tern is not distributed as Docker images yet. This is coming soon. Watch the [Project Status](#project-status) for updates.
 
 ## Getting Started with Vagrant<a name="getting-started-with-vagrant">
-Vagrant is a tool to setup an isolated virtual software development environment. If you are using Windows or Mac OSes, this is the best way to get started as Tern does not run natively in a Mac OS or Windows environment at this time.
+Vagrant is a tool to setup an isolated virtual software development environment. If you are using Windows or Mac OSes and want to run Tern from the command line (not in a Docker container) this is the best way to get started as Tern does not run natively in a Mac OS or Windows environment at this time.
 
 ### Install
 Follow the instructions on the [VirtualBox](https://www.virtualbox.org/wiki/Downloads) website to download VirtualBox on your OS.

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,19 +1,17 @@
-# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-FROM photon:3.0
+FROM debian:buster
 
-# install system dependencies
-# photon:3.0 comes with toybox which conflicts with some dependencies needed for tern to work, so uninstalling
-# toybox first
-RUN tdnf remove -y toybox && tdnf install -y tar findutils attr util-linux python3 python3-pip python3-setuptools git && pip3 install --upgrade pip
+# Install fuse-overlayfs and Tern dependencies
+RUN apt-get update && apt-get -y install wget gnupg2 tar findutils attr util-linux python3 python3-pip python3-setuptools git && pip3 install --upgrade pip && echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_10/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list && wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/Debian_10/Release.key -O Release.key && apt-key add - < Release.key && apt-get update -qq && apt-get -qq -y install buildah fuse-overlayfs && rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
-# install tern with latest changes
+# Install tern with latest changes
 COPY dist/tern-*.tar.gz .
 RUN pip install tern-*.tar.gz
 
-# make a mounting directory
-RUN mkdir hostmount
+# Adjust storage.conf to enable Fuse storage.
+RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' /etc/containers/storage.conf
 
-ENTRYPOINT ["tern", "-q", "-b", "/hostmount"]
+ENTRYPOINT ["tern", "--driver", "fuse"]
 CMD ["-h"]

--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -41,7 +41,7 @@ test_suite = {
     re.compile('Dockerfile'): [
         'python3 setup.py sdist && '
         'docker build -t ternd -f ci/Dockerfile . && '
-        './docker_run.sh workdir ternd "report -i golang:alpine"'],
+        './docker_run.sh ternd "report -i golang:alpine"'],
     # Files under tern directory
     re.compile('tern/__init__.py|tern/__main__.py'):
     ['tern  report -i golang:alpine'],

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 #
 # Script to run Tern within a prebuilt Docker container
@@ -8,8 +8,7 @@
 # The script will make a directory that you provide
 # It will then run a docker container in privileged mode and bind mount to the directory
 #
-# Usage: ./docker_run.sh <directory_name> <tern image> <tern command arguments in quotes>
-# Example: ./docker_run.sh workdir ternd "report -i golang:alpine"
+# Usage: ./docker_run.sh <tern image> <tern command arguments in quotes> > output.txt
+# Example: ./docker_run.sh ternd "report -i golang:alpine" > output.txt
 
-mkdir -p $1
-docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock --mount type=bind,source=$PWD/$1,target=/hostmount --rm $2 $3
+docker run --privileged --device /dev/fuse -v /var/run/docker.sock:/var/run/docker.sock --rm $1 $2

--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -71,8 +71,8 @@ def create_top_dir(working_dir=None):
 
 def do_main(args):
     '''Execute according to subcommands'''
-    # set bind mount location if working in a container
-    rootfs.set_mount_dir(args.bind_mount, args.working_dir)
+    # Set mount/working dir according to user
+    rootfs.set_working_dir(args.working_dir)
     # create working directory
     create_top_dir(args.working_dir)
     if not args.quiet:
@@ -131,14 +131,17 @@ def main():
     parser.add_argument('-k', '--keep-wd', action='store_true',
                         help="Keep the working directory after execution."
                         " Useful when debugging container images")
-    parser.add_argument('-b', '--bind-mount', metavar='BIND_DIR',
-                        help="Absolute path to bind mount target. Needed"
-                        " when running from within a container.")
     parser.add_argument('-r', '--redo', action='store_true',
                         help="Repopulate the cache for found layers")
     parser.add_argument('-wd', '--working-dir', metavar='PATH',
                         help="Change default working directory to specified"
                         "absolute path.")
+    parser.add_argument('-d', '--driver', metavar="DRIVER_OPTION",
+                        help="Required when running Tern in a container."
+                        "Using 'fuse' will enable the fuse-overlayfs driver "
+                        "to mount the diff layers of the container. If no "
+                        "input is provided, 'fuse' will be used as the "
+                        "default option.")
     # sys.version gives more information than we care to print
     py_ver = sys.version.replace('\n', '').split('[')[0]
     parser.add_argument('-v', '--version', action='version',

--- a/tern/analyze/docker/run.py
+++ b/tern/analyze/docker/run.py
@@ -66,7 +66,8 @@ def analyze(image_obj, args, dfile_lock=False, dfobj=None):
     if not dfile_lock and args.extend:
         run_extension(image_obj, args.extend, args.redo)
     else:
-        analyze_docker_image(image_obj, args.redo, dfile_lock, dfobj)
+        analyze_docker_image(image_obj, args.redo, dfile_lock, dfobj,
+                             args.driver)
 
 
 def execute_docker_image(args):

--- a/tern/tools/container_debug.py
+++ b/tern/tools/container_debug.py
@@ -90,7 +90,7 @@ if __name__ == '__main__':
     parser.add_argument('--clean', action='store_true',
                         help='Clean up the mounts')
     args = parser.parse_args()
-    rootfs.set_mount_dir()
+    rootfs.set_working_dir()
 
     # check if we need to clean
     if args.clean:

--- a/tern/tools/verify_invoke.py
+++ b/tern/tools/verify_invoke.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
     # do initial setup to analyze docker image
     container.check_docker_setup()
     # set some global variables
-    rootfs.set_mount_dir()
+    rootfs.set_working_dir()
     # try to load the image
     image_obj = report.load_full_image(args.image)
     if image_obj.origins.is_empty():

--- a/tern/utils/cache.py
+++ b/tern/utils/cache.py
@@ -30,10 +30,10 @@ def load():
     global cache
 
     # Do not try to populate the cache if there is no cache available
-    if not os.path.exists(os.path.join(rootfs.mount_dir, cache_file)):
+    if not os.path.exists(os.path.join(rootfs.working_dir, cache_file)):
         return
 
-    with open(os.path.join(rootfs.mount_dir, cache_file)) as f:
+    with open(os.path.join(rootfs.working_dir, cache_file)) as f:
         cache = json.load(f)
 
 
@@ -78,7 +78,7 @@ def add_layer(layer_obj):
 
 def save():
     '''Save the cache to the cache file'''
-    with open(os.path.join(rootfs.mount_dir, cache_file), 'w') as f:
+    with open(os.path.join(rootfs.working_dir, cache_file), 'w') as f:
         json.dump(cache, f)
 
 
@@ -95,5 +95,5 @@ def clear():
     '''Empty the cache - don't use unless you really have to'''
     global cache
     cache = {}
-    with open(os.path.join(rootfs.mount_dir, cache_file), 'w') as f:
+    with open(os.path.join(rootfs.working_dir, cache_file), 'w') as f:
         json.dump(cache, f)

--- a/tests/test_class_docker_image.py
+++ b/tests/test_class_docker_image.py
@@ -10,7 +10,7 @@ from tern.__main__ import create_top_dir
 from tern.analyze.docker import container
 from tern.analyze.docker.container import check_image, check_docker_setup
 from tern.classes.docker_image import DockerImage
-from tern.utils.rootfs import set_mount_dir
+from tern.utils.rootfs import set_working_dir
 
 
 class TestClassDockerImage(unittest.TestCase):
@@ -19,7 +19,7 @@ class TestClassDockerImage(unittest.TestCase):
         '''Using a specific image here. If this test fails due to the image
         not being found anymore, pick a different image to test against
         For now use Docker to pull the image from Dockerhub'''
-        set_mount_dir()
+        set_working_dir()
         create_top_dir()
         check_docker_setup()
         if not check_image('vmware/tern@sha256:20b32a9a20752aa1ad'


### PR DESCRIPTION
Tern does not currently run within a container image without an external
mount to a linux host. This pull request updates the code as well as the
Dockerfile and docker_run.sh script to install fuse-overlayfs and use it to
mount the diff layers when the --non-linux command line option is
envoked. These changes will enable Tern to run in a container on a
non-Linux host instead of having to use vagrant.

Resolves #679 

Signed-off-by: Rose Judge <rjudge@vmware.com>