### PR TITLE
Skip empty layers during analysis

### DIFF
--- a/tern/analyze/common.py
+++ b/tern/analyze/common.py
@@ -181,6 +181,14 @@ def get_shell(layer):
     return shell
 
 
+def is_empty_layer(layer):
+    '''Return True if the given image layer is empty'''
+    cwd = rootfs.get_untar_dir(layer.tar_file)
+    if len(os.listdir(cwd)) == 0:
+        return True
+    return False
+
+
 def get_os_release(base_layer):
     '''Given the base layer object, determine if an os-release file exists and
     return the PRETTY_NAME string from it. If no release file exists,

--- a/tern/analyze/docker/analyze.py
+++ b/tern/analyze/docker/analyze.py
@@ -63,6 +63,12 @@ def abort_analysis():
 def analyze_first_layer(image_obj, master_list, redo):
     # set up a notice origin for the first layer
     origin_first_layer = 'Layer {}'.format(image_obj.layers[0].layer_index)
+    # check if the layer is empty
+    if common.is_empty_layer(image_obj.layers[0]):
+        logger.warning(errors.empty_layer)
+        image_obj.layers[0].origins.add_notice_to_origins(
+            origin_first_layer, Notice(errors.empty_layer, 'warning'))
+        return ''
     # find the shell from the first layer
     shell = common.get_shell(image_obj.layers[0])
     if not shell:
@@ -109,6 +115,17 @@ def analyze_subsequent_layers(image_obj, shell, master_list, redo, dfobj=None,  
     curr_layer = 1
     work_dir = None
     while curr_layer < len(image_obj.layers):  # pylint:disable=too-many-nested-blocks
+        # make a notice for each layer
+        origin_next_layer = 'Layer {}'.format(
+            image_obj.layers[curr_layer].layer_index)
+        # check if this is an empty layer
+        if common.is_empty_layer(image_obj.layers[curr_layer]):
+            # we continue to the next layer
+            logger.warning(errors.empty_layer)
+            image_obj.layers[curr_layer].origins.add_notice_to_origins(
+                origin_next_layer, Notice(errors.empty_layer, 'warning'))
+            curr_layer = curr_layer + 1
+            continue
         # If workdir changes, update value accordingly
         # so we can later execute base.yml commands from the workdir.
         if image_obj.layers[curr_layer].get_layer_workdir() is not None:

--- a/tern/report/errors.py
+++ b/tern/report/errors.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 """
@@ -77,6 +77,7 @@ no_running_docker_container = '''Cannot invoke commands in a container '''\
     '''as there is no running container.\n'''
 cannot_find_image = '''Cannot find image {imagetag} locally or from remote '''\
     '''registry.\n'''
+empty_layer = '''Empty layer. Nothing to do.\n'''
 
 # not error messages but stuff for the logger
 no_base_image = '''Base image is FROM scratch. Skipping to build'''

--- a/tern/utils/rootfs.py
+++ b/tern/utils/rootfs.py
@@ -117,8 +117,6 @@ def check_tar_members(tar_file):
         else:
             logger.error("Malformed tar: %s", error_msg)
             raise EOFError("Malformed tarball: {}".format(tar_file))
-    if not result:
-        raise ValueError("Empty tarball: {}".format(tar_file))
     return result
 
 


### PR DESCRIPTION
Previously, we would raise a ValueError when a layer tarball was
empty. This would terminate analysis as soon as an empty layer was
discovered. This change allows us to give a warning and skip
analysis instead, so images with empty layers can be analyzed.

- Remove the check for empty layers.
- Add a function to check if a layer is empty by checking to see
  if the untarred directory is empty.
- Use the function during analysis to check if a layer is empty
  and skip analysis for the first and subsequent layers.
- Added a new "empty layer" error message.

Fixes #686

Signed-off-by: Nisha K <nishak@vmware.com>