### PR TITLE
Set environment vars before package collection

### DIFF
--- a/tern/analyze/common.py
+++ b/tern/analyze/common.py
@@ -217,7 +217,7 @@ def get_os_release(base_layer):
     return pretty_name.strip('"')
 
 
-def collate_list_metadata(shell, listing, work_dir):
+def collate_list_metadata(shell, listing, work_dir, envs):
     '''Given the shell and the listing for the package manager, collect
     metadata that gets returned as a list'''
     pkg_dict = {}
@@ -228,7 +228,8 @@ def collate_list_metadata(shell, listing, work_dir):
         return pkg_dict, msgs, warnings
     for item in command_lib.base_keys:
         if item in listing.keys():
-            items, msg = command_lib.get_pkg_attr_list(shell, listing[item], work_dir)
+            items, msg = command_lib.get_pkg_attr_list(shell, listing[item],
+                                                       work_dir, envs)
             msgs = msgs + msg
             pkg_dict.update({item: items})
         else:
@@ -306,7 +307,7 @@ def get_deb_package_licenses(deb_copyrights):
     return deb_licenses
 
 
-def add_base_packages(image_layer, binary, shell, work_dir=None):
+def add_base_packages(image_layer, binary, shell, work_dir=None, envs=None):
     '''Given the image layer, the binary to invoke and shell:
         1. get the listing from the base.yml
         2. Invoke any commands against the base layer
@@ -329,7 +330,8 @@ def add_base_packages(image_layer, binary, shell, work_dir=None):
         image_layer.origins.add_notice_to_origins(
             origin_layer, Notice(snippet_msg, 'info'))
         # get all the packages in the base layer
-        pkg_dict, invoke_msg, warnings = collate_list_metadata(shell, listing, work_dir)
+        pkg_dict, invoke_msg, warnings = collate_list_metadata(shell, listing,
+                                                               work_dir, envs)
 
         if listing.get("pkg_format") == "deb":
             pkg_dict["pkg_licenses"] = get_deb_package_licenses(
@@ -354,7 +356,7 @@ def add_base_packages(image_layer, binary, shell, work_dir=None):
                 listing_key=binary), 'error'))
 
 
-def fill_package_metadata(pkg_obj, pkg_listing, shell, work_dir):
+def fill_package_metadata(pkg_obj, pkg_listing, shell, work_dir, envs):
     '''Given a Package object and the Package listing from the command
     library, fill in the attribute value returned from looking up the
     data and methods of the package listing.
@@ -367,7 +369,7 @@ def fill_package_metadata(pkg_obj, pkg_listing, shell, work_dir):
         pkg_listing, 'version')
     if version_listing:
         version_list, invoke_msg = command_lib.get_pkg_attr_list(
-            shell, version_listing, work_dir, package_name=pkg_obj.name)
+            shell, version_listing, work_dir, envs, package_name=pkg_obj.name)
         if version_list:
             pkg_obj.version = version_list[0]
         else:
@@ -381,7 +383,7 @@ def fill_package_metadata(pkg_obj, pkg_listing, shell, work_dir):
         pkg_listing, 'license')
     if license_listing:
         license_list, invoke_msg = command_lib.get_pkg_attr_list(
-            shell, license_listing, work_dir, package_name=pkg_obj.name)
+            shell, license_listing, work_dir, envs, package_name=pkg_obj.name)
         if license_list:
             pkg_obj.license = license_list[0]
         else:
@@ -395,7 +397,7 @@ def fill_package_metadata(pkg_obj, pkg_listing, shell, work_dir):
         pkg_listing, 'proj_url')
     if url_listing:
         url_list, invoke_msg = command_lib.get_pkg_attr_list(
-            shell, url_listing, work_dir, package_name=pkg_obj.name)
+            shell, url_listing, work_dir, envs, package_name=pkg_obj.name)
         if url_list:
             pkg_obj.proj_url = url_list[0]
         else:
@@ -406,7 +408,8 @@ def fill_package_metadata(pkg_obj, pkg_listing, shell, work_dir):
             origin_str, Notice(listing_msg, 'warning'))
 
 
-def get_package_dependencies(package_listing, package_name, shell, work_dir=None):
+def get_package_dependencies(package_listing, package_name, shell,
+                             work_dir=None, envs=None):
     '''The package listing is the result of looking up the command name in the
     command library. Given this listing, the package name and the shell
     return a list of package dependency names'''
@@ -414,7 +417,7 @@ def get_package_dependencies(package_listing, package_name, shell, work_dir=None
         package_listing, 'deps')
     if deps_listing:
         deps_list, invoke_msg = command_lib.get_pkg_attr_list(
-            shell, deps_listing, work_dir, package_name=package_name)
+            shell, deps_listing, work_dir, envs, package_name=package_name)
         if deps_list:
             return list(set(deps_list)), ''
         return [], invoke_msg
@@ -512,7 +515,8 @@ def filter_install_commands(shell_command_line):
     return consolidate_commands(filter2), report
 
 
-def add_snippet_packages(image_layer, command, pkg_listing, shell, work_dir):
+def add_snippet_packages(image_layer, command, pkg_listing, shell, work_dir,  # pylint:disable=too-many-arguments,too-many-locals
+                         envs):
     '''Given an image layer object, a command object, the package listing
     and the shell used to invoke commands, add package metadata to the layer
     object. We assume the filesystem is already mounted and ready
@@ -545,7 +549,7 @@ def add_snippet_packages(image_layer, command, pkg_listing, shell, work_dir):
     # get package metadata for each package name
     for pkg_name in unique_pkgs:
         pkg = Package(pkg_name)
-        fill_package_metadata(pkg, pkg_invoke, shell, work_dir)
+        fill_package_metadata(pkg, pkg_invoke, shell, work_dir, envs)
         image_layer.add_package(pkg)
 
 

--- a/tern/analyze/docker/analyze.py
+++ b/tern/analyze/docker/analyze.py
@@ -146,10 +146,13 @@ def analyze_subsequent_layers(image_obj, shell, master_list, redo, dfobj=None,  
             # for each command look up the snippet library
             for command in command_list:
                 pkg_listing = command_lib.get_package_listing(command.name)
+                # get list of environment variables
+                envs = dhelper.get_env_vars(image_obj)
                 if isinstance(pkg_listing, str):
                     try:
                         common.add_base_packages(
-                            image_obj.layers[curr_layer], pkg_listing, shell, work_dir)
+                            image_obj.layers[curr_layer], pkg_listing, shell,
+                            work_dir, envs)
                     except KeyboardInterrupt:
                         logger.critical(errors.keyboard_interrupt)
                         abort_analysis()
@@ -157,7 +160,7 @@ def analyze_subsequent_layers(image_obj, shell, master_list, redo, dfobj=None,  
                     try:
                         common.add_snippet_packages(
                             image_obj.layers[curr_layer], command, pkg_listing,
-                            shell, work_dir)
+                            shell, work_dir, envs)
                     except KeyboardInterrupt:
                         logger.critical(errors.keyboard_interrupt)
                         abort_analysis()

--- a/tern/analyze/docker/helpers.py
+++ b/tern/analyze/docker/helpers.py
@@ -201,3 +201,10 @@ def set_imported_layers(docker_image):
         # index was set so all layers before this index has been imported
         for i in range(0, index):
             docker_image.layers[i].import_str = from_line
+
+
+def get_env_vars(image_obj):
+    '''Given a docker image object, return the list of environment variables,
+    if any, based on their values in the config.'''
+    config = image_obj.get_image_config(image_obj.get_image_manifest())
+    return config['config']['Env']

--- a/tern/command_lib/command_lib.py
+++ b/tern/command_lib/command_lib.py
@@ -205,8 +205,8 @@ def invoke_in_rootfs(snippet_list, shell, package=''):
         raise
 
 
-def get_pkg_attr_list(shell, attr_dict, work_dir, package_name='', chroot=True,  # pylint:disable=too-many-arguments
-                      override=''):
+def get_pkg_attr_list(shell, attr_dict, work_dir, envs, package_name='',  # pylint:disable=too-many-arguments
+                      chroot=True, override=''):
     '''The command library has package attributes listed like this:
         {invoke: {1: {container: [command1, command2]},
                   2: {host: [command1, command2]}}, delimiter: <delimiter}
@@ -225,6 +225,11 @@ def get_pkg_attr_list(shell, attr_dict, work_dir, package_name='', chroot=True, 
             if 'container' in attr_dict['invoke'][step].keys():
                 snippet_list = attr_dict['invoke'][step]['container']
                 result = ''
+                # If environment variables exist, set them
+                if envs:
+                    for var in envs:
+                        snippet_list.insert(0, 'export ' + var.split('=')[0] +
+                                            '=' + var.split('=')[1])
                 # If work_dir exist cd into it
                 if work_dir is not None:
                     snippet_list.insert(0, 'cd ' + work_dir)

--- a/tern/tools/verify_invoke.py
+++ b/tern/tools/verify_invoke.py
@@ -16,6 +16,7 @@ from tern.utils import rootfs
 from tern.report import report
 from tern.analyze.docker import container
 from tern.analyze.docker import analyze
+from tern.analyze.docker import helpers
 
 
 def look_up_lib(keys):
@@ -88,8 +89,9 @@ if __name__ == '__main__':
         # try to invoke the commands
         try:
             work_dir = get_workdir(image_obj)
+            envs = helpers.get_env_vars(image_obj)
             result = command_lib.get_pkg_attr_list(
-                args.shell, info_dict, work_dir, args.package)
+                args.shell, info_dict, work_dir, envs, args.package)
             print('Output list: ' + ' '.join(result[0]))
             print('Error messages: ' + result[1])
             print('Number of elements: ' + str(len(result[0])))


### PR DESCRIPTION
Some Docker images have environment variables defined in the config.json
file. This is especially true in images where go modules are used
or installed as this is where the PATH and GOPATH are set. This
commit adds functionality to set/export the environment variables from
the config in each image layer before package information is collected.
If environment variables exist in the image config that are not relevant
to the layer and its method of package collection, the environment
variables will simply be ignored by the package collection commands.

Works towards #695

Signed-off-by: Rose Judge <rjudge@vmware.com>