### PR TITLE
Add logic to find shell in Alpine images

### DIFF
--- a/tern/analyze/common.py
+++ b/tern/analyze/common.py
@@ -175,6 +175,13 @@ def get_shell(layer):
     shell = ''
     cwd = rootfs.get_untar_dir(layer.tar_file)
     for sh in command_lib.command_lib['common']['shells']:
+        realpath = os.path.realpath(os.path.join(cwd, sh[1:]))
+        # If realpath is a symlink and points to the root of the container,
+        # check for existence of the linked binary in current working dir
+        if realpath[0] == '/' and os.path.exists(os.path.join(cwd,
+                                                              realpath[1:])):
+            return sh
+        # otherwise, just follow symlink in same folder and
         # remove leading forwardslash before joining paths
         if os.path.exists(os.path.join(cwd, sh[1:])):
             return sh


### PR DESCRIPTION
Alpine images symlink the /bin/sh utility to an absolute path,
/bin/busybox. The current get_shell() function uses os.path.exists to
verify the existence of the shell path. In the case of Alpine images,
however, os.path.exists follows the /bin/sh symlink to the root of the
host container, /bin/busybox, which will only exist if busybox is
installed on the host container. This commit adds logic to follow
absolute shell path symlinks to the correct binary location in the
mounted working directory instead of looking for it in the root of the
host container.

Resolves #769

Signed-off-by: Rose Judge <rjudge@vmware.com>