### PR TITLE
Refactor Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,34 @@
 FROM debian:buster
 
 # Install fuse-overlayfs and Tern dependencies
-RUN apt-get update && apt-get -y install wget gnupg2 tar findutils attr util-linux python3 python3-pip python3-setuptools git && pip3 install --upgrade pip && pip3 install tern && echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_10/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list && wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/Debian_10/Release.key -O Release.key && apt-key add - < Release.key && apt-get update -qq && apt-get -qq -y install buildah fuse-overlayfs && rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+RUN apt-get update && \
+    apt-get -y install \
+    attr \
+    findutils \
+    git \
+    gnupg2 \
+    python3 \
+    python3-pip \
+    python3-setuptools \
+    tar \
+    util-linux \
+    wget && \
+    echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_10/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list && \
+    wget --no-verbose https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/Debian_10/Release.key -O - | apt-key add - && \
+    apt-get update && \
+    apt-get -y install \
+    buildah \
+    fuse-overlayfs && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Adjust storage.conf to enable Fuse storage.
 RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' /etc/containers/storage.conf
+
+# Install tern
+RUN pip3 install --upgrade pip && \
+    pip3 install --no-cache-dir \
+    tern
 
 ENTRYPOINT ["tern", "--driver", "fuse"]
 CMD ["-h"]

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -4,14 +4,35 @@
 FROM debian:buster
 
 # Install fuse-overlayfs and Tern dependencies
-RUN apt-get update && apt-get -y install wget gnupg2 tar findutils attr util-linux python3 python3-pip python3-setuptools git && pip3 install --upgrade pip && echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_10/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list && wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/Debian_10/Release.key -O Release.key && apt-key add - < Release.key && apt-get update -qq && apt-get -qq -y install buildah fuse-overlayfs && rm -rf /var/cache /var/log/dnf* /var/log/yum.*
-
-# Install tern with latest changes
-COPY dist/tern-*.tar.gz .
-RUN pip install tern-*.tar.gz
+RUN apt-get update && \
+    apt-get -y install \
+    attr \
+    findutils \
+    git \
+    gnupg2 \
+    python3 \
+    python3-pip \
+    python3-setuptools \
+    tar \
+    util-linux \
+    wget && \
+    echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_10/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list && \
+    wget --no-verbose https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/Debian_10/Release.key -O - | apt-key add - && \
+    apt-get update && \
+    apt-get -y install \
+    buildah \
+    fuse-overlayfs && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Adjust storage.conf to enable Fuse storage.
 RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' /etc/containers/storage.conf
+
+# Install tern with latest changes
+COPY dist/tern-*.tar.gz .
+RUN pip3 install --upgrade pip && \
+    pip3 install --no-cache-dir \
+    tern-*.tar.gz
 
 ENTRYPOINT ["tern", "--driver", "fuse"]
 CMD ["-h"]


### PR DESCRIPTION
The Dockerfiles were previously quite hard to read as the commands
were done as one-liners. This change adds newlines to the commands
to improve the readability.

Installation of pip packages is also moved to its own layer, which
allows us to utilize the layer cache for apt packages in case more pip
packages need to be installed later on (e.g. scancode-toolkit) to the
image.

Signed-off-by: Isac Sund <isac@isacsund.com>