### PR TITLE
Fix error caused by tabs in ENV

### DIFF
--- a/tern/analyze/docker/helpers.py
+++ b/tern/analyze/docker/helpers.py
@@ -207,4 +207,7 @@ def get_env_vars(image_obj):
     '''Given a docker image object, return the list of environment variables,
     if any, based on their values in the config.'''
     config = image_obj.get_image_config(image_obj.get_image_manifest())
+    # replace '\t' with '\\t'  in the ENV
+    for idx, env_str in enumerate(config['config']['Env']):
+        config['config']['Env'][idx] = env_str.replace('\t', '\\t')
     return config['config']['Env']


### PR DESCRIPTION
This commit replace '\t' with '\\t' in the ENV command. This will allow
'export VAR=VAL' works properly when VAL contains '\t'.

Fixes #812.

Signed-off-by: WangJL <hazard15020@gmail.com>