### PR TITLE
Add `apt` Snippet In Command Library

### DIFF
--- a/tern/analyze/default/command_lib/snippets.yml
+++ b/tern/analyze/default/command_lib/snippets.yml
@@ -15,6 +15,15 @@ apt-get:
     - 'update'
   packages: 'dpkg' # refer to base.yml's method of collection
 
+apt:
+  install:
+    - 'install' # subcommand to install
+  remove:
+    - 'purge' # subcommand to remove a package
+  ignore: # list of subcommands that don't add or remove packages
+    - 'update'
+  packages: 'dpkg' # refer to base.yml's method of collection
+
 tyum:
   install:
     - 'install'


### PR DESCRIPTION
Add `apt` command to `snippets.yml` present under `command_lib`

Resolves #512

Signed-off-by: @HeroicHitesh hiteshkumar_1mv17cs042@sirmvit.edu