### PR TITLE
Fix unbound local error when repo digest is given

### DIFF
--- a/tern/analyze/default/container/image.py
+++ b/tern/analyze/default/container/image.py
@@ -23,9 +23,9 @@ from tern.report import formats
 logger = logging.getLogger(constants.logger_name)
 
 
-def load_full_image(image_tag_string, digest_string):
+def load_full_image(image_tag_string):
     '''Create image object from image name and tag and return the object'''
-    test_image = DockerImage(image_tag_string, digest_string)
+    test_image = DockerImage(image_tag_string)
     failure_origin = formats.image_load_failure.format(
         testimage=test_image.repotag)
     try:

--- a/tern/analyze/default/container/run.py
+++ b/tern/analyze/default/container/run.py
@@ -31,20 +31,22 @@ def extract_image(args):
         # extract the docker image
         image_attrs = docker_api.dump_docker_image(args.docker_image)
         if image_attrs:
+            # repo name and digest is preferred, but if that doesn't exist
+            # the repo name and tag will do
+            if image_attrs['RepoDigests']:
+                image_string = image_attrs['RepoDigests'][0]
             if image_attrs['RepoTags']:
                 image_string = image_attrs['RepoTags'][0]
-            if image_attrs['RepoDigests']:
-                image_digest = image_attrs['RepoDigests'][0]
-            return image_string, image_digest
+            return image_string
         logger.critical("Cannot extract Docker image")
     if args.raw_image:
         # for now we assume that the raw image tarball is always
         # the product of "docker save", hence it will be in
         # the docker style layout
         if rootfs.extract_tarfile(args.raw_image, rootfs.get_working_dir()):
-            return args.raw_image, None
+            return args.raw_image
         logger.critical("Cannot extract raw image")
-    return None, None
+    return None
 
 
 def setup(image_obj):
@@ -68,10 +70,10 @@ def teardown(image_obj):
 def execute_image(args):
     """Execution path for container images"""
     logger.debug('Starting analysis...')
-    image_string, image_digest = extract_image(args)
+    image_string = extract_image(args)
     # If the image has been extracted, load the metadata
     if image_string:
-        full_image = cimage.load_full_image(image_string, image_digest)
+        full_image = cimage.load_full_image(image_string)
         # check if the image was loaded successfully
         if full_image.origins.is_empty():
             # Add an image origin here

--- a/tern/analyze/default/dockerfile/run.py
+++ b/tern/analyze/default/dockerfile/run.py
@@ -121,7 +121,7 @@ def full_image_analysis(dfile, redo, driver, keep, extension):
     """This subroutine is executed when a Dockerfile is successfully built"""
     image_list = []
     # attempt to load the built image metadata
-    full_image = cimage.load_full_image(dfile, '')
+    full_image = cimage.load_full_image(dfile)
     if full_image.origins.is_empty():
         # Add an image origin here
         full_image.origins.add_notice_origin(


### PR DESCRIPTION
The DockerImage class can accept an image string in the form
image:tag or image@digest_type:digest. It can also accept an
optional digest string of the form digest_type:digest if the image
string is not known.

For the current status of running analysis on Docker style container
image names, the optional digest is not required. Therefore this
commit removes using the second digest string. To that effect
the changes are made in the extract_image, load_full_image and
load_base_image functions.

This also fixes #797

Signed-off-by: Nisha K <nishak@vmware.com>