### PR TITLE
Gracefully exit if there is no image to analyze

### DIFF
--- a/tern/analyze/default/container/run.py
+++ b/tern/analyze/default/container/run.py
@@ -90,6 +90,5 @@ def execute_image(args):
         else:
             # we cannot load the full image
             logger.error('Cannot retrieve full image metadata')
-    # cleanup
-    if not args.keep_wd:
-        prep.clean_image_tars(full_image)
+        if not args.keep_wd:
+            prep.clean_image_tars(full_image)

--- a/tern/load/docker_api.py
+++ b/tern/load/docker_api.py
@@ -158,7 +158,7 @@ def pull_image(image_tag_string, client):
         logger.debug("Image \"%s\" downloaded", image_tag_string)
         return image
     except (docker.errors.ImageNotFound, docker.errors.NotFound):
-        logger.warning("No such image: \"%s\"", image_tag_string)
+        logger.error("No such image: \"%s\"", image_tag_string)
         return None
 
 
@@ -196,9 +196,9 @@ def dump_docker_image(image_tag):
     # if this fails we cannot proceed further so we will exit
     client = check_docker_setup()
     image = get_docker_image(image_tag, client)
-    # this should return whether the operation succeeded or not
-    if extract_image(image):
-        image_metadata = image.attrs
+    if image:
+        if extract_image(image):
+            image_metadata = image.attrs
     # now the client can be closed
     close_client(client)
     return image_metadata


### PR DESCRIPTION
- Fixed dump_docker_image function if an image is downloaded.
- Clean image tarballs only if an image is successfully extracted.

Fixes #828

Signed-off-by: Nisha K <nishak@vmware.com>