### PR TITLE
Fix crash when a chroot command fails

### DIFF
--- a/tern/analyze/default/collect.py
+++ b/tern/analyze/default/collect.py
@@ -78,7 +78,7 @@ def get_pkg_attrs(attr_dict, shell, work_dir=None, envs=None, package_name=''):
                         snippet_list, shell, package=package_name)
                     result = result[:-1]
                 except subprocess.CalledProcessError as error:
-                    error_msgs = error_msgs + error.output
+                    error_msgs = error_msgs + error.stderr
     if 'delimiter' in attr_dict.keys():
         res_list = result.split(attr_dict['delimiter'])
         if res_list[-1] == '':

--- a/tern/utils/rootfs.py
+++ b/tern/utils/rootfs.py
@@ -238,10 +238,10 @@ def run_chroot_command(command_string, shell):
         result = root_command(unshare_pid, mount_proc, 'chroot', target_dir,
                               shell, '-c', command_string)
         return result
-    except subprocess.CalledProcessError as error:
+    except subprocess.CalledProcessError as e:
         logger.warning("Error executing command in chroot")
         raise subprocess.CalledProcessError(
-            1, cmd=command_string, output=error.output.decode('utf-8'))
+            1, cmd=command_string, output=None, stderr=e.stderr)
 
 
 def undo_mount():


### PR DESCRIPTION
Tern should recover from a command invocation failure, while
recording the reason for the failure. This commit fixes the
crashing due to improper bubbling up of the error message.
Use CalledProcessError exception's stderr property.

Fixes #822

Signed-off-by: Nisha K <nishak@vmware.com>