### PR TITLE
Update code navigation document

### DIFF
--- a/docs/navigating-the-code.md
+++ b/docs/navigating-the-code.md
@@ -1,25 +1,34 @@
 # Navigating Tern's Code
 
-To help with code navigation, looking up the [glossary](/docs/glossary.md) is useful. All the code lives in the directory `tern`. The rest of the stuff in the root directory have to do with configurations for build and packaging. If you want to try each of the modules in the Python repl (Read Eval Print Loop), you can reference them from the module `tern`.
+To help with code navigation, looking up the [glossary](/docs/glossary.md) is useful. All the code lives in the directory `tern`. The rest of the files in the root repository have to do with configurations for build and packaging. If you want to try each of the modules in the Python repl (Read Eval Print Loop), you can reference them from the module `tern`. For example:
+
+```
+from tern.utils import rootfs
+from tern.analyze.default import core
+```
 
 Here is a layout of the directory structure:
 
 ```
 ▾ tern/
-    __main__.py <-- Tern entry point
-
-  ▾ analyze/  <-- Each container image format will have its own subdirectory for analysis
-      common.py <-- Common modules used at a high level throughout the code
-    ▾ docker/
-        analyze.py
-        container.py
-        dockerfile.py
-        docker.py <-- modules specific to Docker
-        run.py
-
-  ▾ classes/  <-- These are individual objects. Each has a corresponding test in the tests directory
+    __main__.py 	  <-- tern entry point (where command line argument parsing lives)
+    prep.py 		  <-- set-up and tear-down operations
+  ▾ analyze/
+      common.py 	  <-- common functions for analysis
+      passthrough.py 	  <-- functions to hand off analysis to an extension
+    ▾ default/ 		  <-- tern's default analysis method
+        bundle.py	  <-- functions to bundle collected data into an Image class
+        collect.py	  <-- functions to collect data
+        core.py		  <-- core subroutines for tern's default operation
+        default_common.py <-- common functions for default operation
+        filter.py
+      ▸ command_lib/      <-- tern's command library
+      ▸ container/	  <-- functions to analyze a container image
+      ▸ dockerfile/	  <-- functions to analyze/lock a Dockerfile
+  ▾ classes/		  <-- python classes to store data collected during analysis
       command.py
       docker_image.py
+      file_data.py
       image.py
       image_layer.py
       notice.py
@@ -27,63 +36,40 @@ Here is a layout of the directory structure:
       origins.py
       package.py
       template.py
-
-  ▾ command_lib/ <-- These are the bash commands that get run to collect information about the container image
-      base.yml <-- System wide scripts for package managers and such
-      snippets.yml <-- scripts for one off commands
-      command_lib.py <-- Command Library modules
-
-  ▾ extensions/ <-- This is the extension plugin library. An extension is an external tool Tern can use to analyze the filesystems in the container image
-      executor.py <-- This is the abstract base class that an extension plugin needs to inherit from
+  ▾ extensions/		  <-- supported extensions
     ▸ cve_bin_tool/
-	executor.py
-    ▾ scancode/
-        executor.py
-
-  ▾ formats/ <-- This is the reporting template plugin library. Each subdirectory is a module that can be dynamically loaded at runtime based on the users report selection
-      generator.py <-- This is the abstract base class for report plugins
-    ▾ default/
-        generator.py
-    ▾ json/
-        generator.py
-    ▾ spdx/
-        formats.py
-        spdx.py
-      ▾ spdxtagvalue/
-           generator.py
-    ▾ yaml/
-         generator.py
-
-  ▾ report/
+    ▸ scancode/
+      executor.py
+  ▾ formats/		  <-- supported reporting formats
+    ▸ default/
+    ▸ html/
+    ▸ json/
+    ▸ spdx/
+    ▸ yaml/
+      generator.py
+  ▾ load/		  <-- functions to fetch and extract container images
+      docker_api.py
+  ▾ report/		  <-- functions for printing strings in the report
       content.py
       errors.py
       formats.py
-      report.py <-- Main reporting module
-
-  ▾ scripts/debian/ <-- Example script to pull sources for debian based images
-    ▾ jessie/
-        sources.list
-      apt_get_sources.sh
-
-  ▾ tools/ <-- Tools that can be used individually or by Tern
-      fs_hash.sh
-      verify_invoke.py
-      container_debug.py
-
-  ▾ utils/ <-- general utility modules used throughout the code
-      cache.py
-      constants.py
-      general.py
-      metadata.py
-      rootfs.py
-```
-
-Tests live outside of the `tern` folder, in a folder called `tests`.
+      report.py
+  ▸ scripts/		  <-- external scripts
+  ▸ utils/		  <-- utilities that are used throughout the code
 
 ```
-▾ tests/
+
+Tests live outside of the `tern` folder, in a folder called `tests`. The file name format is typically `test_path_to_python_file.py` with the exception of `test_fixtures.py` which are classes used for testing 
+
+```
+▾ tests/                                                                                                                                                                                                                        
+    test_analyze_common.py
+    test_analyze_default_common.py
+    test_analyze_default_dockerfile_parse.py
+    test_analyze_default_filter.py
     test_class_command.py
     test_class_docker_image.py
+    test_class_file_data.py
     test_class_image.py
     test_class_image_layer.py
     test_class_notice.py
@@ -91,15 +77,18 @@ Tests live outside of the `tern` folder, in a folder called `tests`.
     test_class_origins.py
     test_class_package.py
     test_class_template.py
-    test_fixtures.py
-    test_util_commands.py
-    test_util_metadata.py
+    test_fixtures.py				<-- classes for testing purposes live here
+    test_load_docker_api.py
+    test_util_general.py
+  ▸ dockerfiles/				<-- Test dockerfiles live here
+
 ```
 
 Scripts used by our CI/CD setup live outside the `tern` folder, in a folder called `ci`.
 
 ```
 ▾ ci/
+    Dockerfile 	           <-- Dockerfile used to test the tip of default branch in a docker container
     evaluate_docs.py
     test_commit_message.py
     test_files_touched.py
@@ -108,11 +97,12 @@ Scripts used by our CI/CD setup live outside the `tern` folder, in a folder call
 Documentation lives in a folder called `docs`. Sample Dockerfile live in a folder called `samples`.
 
 Some general rules about where the code is located:
-- Utilities used anywhere in the project go in `utils`.
-- Class definitions go in `classes`. For clarity, the name of the file is also the name of the class but with an underscore separating the words rather than CamelCase.
-- Any operation related to look up and operations with the Command Library go in `command_lib`.
+- Utilities used anywhere in the project go in `tern/utils`.
+- Class definitions go in `tern/classes`. For clarity, the name of the file is also the name of the class but with an underscore separating the words rather than CamelCase.
+- Any operation that is performed by default (when running `tern report -i image:tag` live in `tern/analyze/default` as opposed to running tern with an extension (`tern report -x scancode -i image:tag`.
+- Any operation related to look up and operations with the Command Library go in `tern/analyze/default/command_lib`.
 - Any documentation goes in `docs`.
-- Any operations related to reporting go in `report`.
+- Any operations related to string manipulation go in `tern/report`.
 - Any sample Dockerfiles go in `samples`. The directory structure needs to be such that the Dockerfile exists along with the image context. This means that when you use "docker build" only the Dockerfile gets sent to the docker daemon rather than the whole directory structure. This saves on build time.
 - The `scripts` directory is not used by the project yet, but there is potential to use it for complicated operations such as extracting source tarballs.
 - All unit and functional tests go in `tests`.
@@ -120,6 +110,12 @@ Some general rules about where the code is located:
 Code organization follows these general rules:
 - Each class is in its own file.
 - Utils are organized based on what they operate on.
-- Subroutines for use in general or under a particular "domain" can live in a default file name called `helpers.py`. You will find plenty of `helpers.py` files within the `analyze` folder.
+- Subroutines usually live in a file named for a particular high-level operation. Please refer to the layout of the code to get an idea of what operation corresponds to what file.
+
+As a community, we try to make it as easy as possible for the code to be approachable. As such, we try to minimize the complexity of the code by following these guidelines:
+- Write simple functions whenever possible. If you find you are using more than 5 arguments or more than 3 if and for loops, try to make a new function that could be called within the original function.
+- Minimize the number of lines in a file. Maintaining large files can be overwhelming. It's totally fine to created a new file if the existing file that is being edited becomes too large.
+- Provide adequate documentation for each of the functions. Describing what the inputs, outputs and operations are for a function will go a long way for others in the community to understand the function operation.
+- Create functions and files in the appropriate place in the codebase. If you are unsure where to create new functions or files, just ask in the GitHub issue you are working on, or create a new one.
 
 [Back to the README](../README.md)


### PR DESCRIPTION
Since the refactor, the code layout has changed. To help our
contributors, this commit updates the navigating-the-code document
to help them find the appropriate files to change and how to
change them.

- Added an example of how to test the functions in python's repl.
- Replaced old layout with new layout.
- Updated the tests folder layout.
- Updated general rules for code layout.
- Added a section on code complexity reduction.

Signed-off-by: Nisha K <nishak@vmware.com>