### PR TITLE
Replace the short driver option with -dr as per #824

### DIFF
--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -119,7 +119,7 @@ def main():
     parser.add_argument('-wd', '--working-dir', metavar='PATH',
                         help="Change default working directory to specified"
                         "absolute path.")
-    parser.add_argument('-d', '--driver', metavar="DRIVER_OPTION",
+    parser.add_argument('-dr', '--driver', metavar="DRIVER_OPTION",
                         help="Required when running Tern in a container."
                         "Using 'fuse' will enable the fuse-overlayfs driver "
                         "to mount the diff layers of the container. If no "


### PR DESCRIPTION
-d is the short version for --dockerfile and is the same for --driver.
This may cause confusion. I replaced -d with -dr.

Signed-off-by: MD. Asif Joardar <mrsparrow04@gmail.com>