### PR TITLE
Add info about Discussions in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,10 @@ We are excited to work with anyone at any level contributing their time and effo
 
 You can contribute in the following ways:
 
+**Start a Discussion**
+- Ask questions about the project goals, features, a specific use case, or clarification on documentation. Asking questions lead to issues being filed, eventually making the project more usable.
+
 **File Issues**
-- Ask questions about the project goals, a specific use case, or clarification on documentation. Asking questions lead to issues being filed, eventually making the project more usable.
 - Run the code against any Docker image you are using, or any of the tests and submit bug reports when you find them.
 
 **Contribute Documentation**


### PR DESCRIPTION
The 'Discussions' GitHub feature was enabled in the Tern repository
and should be used going forward for questions and feature discussions
instead of opening an issue. This commit updates CONTRIBUTING.md to
contain this information.

Signed-off-by: Rose Judge <rjudge@vmware.com>