### PR TITLE
Generate SBoM for specific/until layer

### DIFF
--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -81,6 +81,8 @@ def do_main(args):
         if args.name == 'lock':
             drun.execute_dockerfile(args, True)
         elif args.name == 'report':
+            if args.layer:
+                raise NotImplementedError("This feature is not implemented yet!")
             if args.dockerfile:
                 drun.execute_dockerfile(args)
             elif args.docker_image:
@@ -153,6 +155,13 @@ def main():
     parser_report.add_argument('-w', '--raw-image', metavar='FILE',
                                help="Raw container image that exists locally "
                                "in the form of a tar archive.")
+    parser_report.add_argument('-y', '--layer', metavar='LAYER_NUMBER',
+                               const=1, action='store', dest='load_until_layer',
+                               nargs='?', type=int, default=0,
+                               help="Layer number of the image to analyze."
+                               " Base OS layer is 1. Can only be used with"
+                               " --docker-image/-i analysis. No argument"
+                               " will scan Base OS layer only.")
     parser_report.add_argument('-x', '--extend', metavar='EXTENSION',
                                help="Use an extension to analyze a container "
                                "image. Available extensions:\n cve-bin-tool\n"

--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -81,10 +81,13 @@ def do_main(args):
         if args.name == 'lock':
             drun.execute_dockerfile(args, True)
         elif args.name == 'report':
-            if args.layer or args.layer_inclusive:
-                raise NotImplementedError("This feature is not implemented yet!")
             if args.dockerfile:
-                drun.execute_dockerfile(args)
+                if (not args.load_until_layer):
+                    drun.execute_dockerfile(args)
+                else:
+                    logger.critical("Currently --layer/-y can only be used with"
+                                    " --docker-image/-i")
+                    sys.exit(1)
             elif args.docker_image:
                 # Check if the image string is a tarball
                 if general.check_tar(args.docker_image):

--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -81,7 +81,7 @@ def do_main(args):
         if args.name == 'lock':
             drun.execute_dockerfile(args, True)
         elif args.name == 'report':
-            if args.layer:
+            if args.layer or args.layer_inclusive:
                 raise NotImplementedError("This feature is not implemented yet!")
             if args.dockerfile:
                 drun.execute_dockerfile(args)
@@ -162,6 +162,11 @@ def main():
                                " Base OS layer is 1. Can only be used with"
                                " --docker-image/-i analysis. No argument"
                                " will scan Base OS layer only.")
+    parser_report.add_argument('-li', '--layer-inclusive',
+                               action='store_true', dest='print_inclusive',
+                               help="Usable only with --layer/-y parameter."
+                               " When used, report will include all"
+                               " preceding layers info.")
     parser_report.add_argument('-x', '--extend', metavar='EXTENSION',
                                help="Use an extension to analyze a container "
                                "image. Available extensions:\n cve-bin-tool\n"

--- a/tern/analyze/default/container/image.py
+++ b/tern/analyze/default/container/image.py
@@ -23,13 +23,14 @@ from tern.report import formats
 logger = logging.getLogger(constants.logger_name)
 
 
-def load_full_image(image_tag_string):
-    '''Create image object from image name and tag and return the object'''
+def load_full_image(image_tag_string, load_until_layer=0):
+    '''Create image object from image name and tag and return the object.
+    Loads only as much layers as needed.'''
     test_image = DockerImage(image_tag_string)
     failure_origin = formats.image_load_failure.format(
         testimage=test_image.repotag)
     try:
-        test_image.load_image()
+        test_image.load_image(load_until_layer)
     except (NameError,
             subprocess.CalledProcessError,
             IOError,

--- a/tern/analyze/default/container/image.py
+++ b/tern/analyze/default/container/image.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(constants.logger_name)
 
 def load_full_image(image_tag_string, load_until_layer=0):
     '''Create image object from image name and tag and return the object.
-    Loads only as much layers as needed.'''
+    Loads only as many layers as needed.'''
     test_image = DockerImage(image_tag_string)
     failure_origin = formats.image_load_failure.format(
         testimage=test_image.repotag)
@@ -47,8 +47,8 @@ def default_analyze(image_obj, redo=False, driver=None):
     """ Steps to analyze a container image (we assume it is a DockerImage
     object for now)
     1. Analyze the first layer to get a baseline list of packages
-    3. Analyze subsequent layers
-    4. Return the final image with all metadata filled in
+    2. Analyze subsequent loaded layers
+    3. Return the final image with all metadata filled in
     Options:
         redo: do not use the cache; False by default
         driver: mount using the chosen driver;

--- a/tern/analyze/default/container/run.py
+++ b/tern/analyze/default/container/run.py
@@ -73,7 +73,7 @@ def execute_image(args):
     image_string = extract_image(args)
     # If the image has been extracted, load the metadata
     if image_string:
-        full_image = cimage.load_full_image(image_string)
+        full_image = cimage.load_full_image(image_string, args.load_until_layer)
         # check if the image was loaded successfully
         if full_image.origins.is_empty():
             # Add an image origin here

--- a/tern/analyze/default/dockerfile/run.py
+++ b/tern/analyze/default/dockerfile/run.py
@@ -88,7 +88,7 @@ def load_base_image():
     if docker_api.dump_docker_image(base_image.repotag):
         # now see if we can load the image
         try:
-            base_image.load_image()
+            base_image.load_image(load_until_layer=0)
         except (NameError,
                 subprocess.CalledProcessError,
                 IOError,

--- a/tern/classes/docker_image.py
+++ b/tern/classes/docker_image.py
@@ -131,7 +131,7 @@ class DockerImage(Image):
                     self._layers[index].created_by = ''
                 index = index + 1
 
-    def load_image(self):
+    def load_image(self, load_until_layer=0):
         """Load metadata from an extracted docker image. This assumes the
         image has already been downloaded and extracted into the working
         directory"""

--- a/tern/classes/image.py
+++ b/tern/classes/image.py
@@ -15,7 +15,10 @@ class Image:
         identification scheme, this can be any string.
         manifest: the json object representing the image manifest
         config: the image config metadata
-        layers: list of layer objects in the image
+        layers: list of loaded layer objects from the image
+                (depends on --layer option)
+        load_until_layer: image should be loaded up to this layer
+        total_layers: total number of layers in image.
         checksum_type: the digest algorithm used to create the image checksum
         checksum: the checksum
         checksums: a list of tuples of the form (checksum_type, checksum)
@@ -34,6 +37,8 @@ class Image:
         self._manifest = {}
         self._config = {}
         self._layers = []
+        self._load_until_layer = 0
+        self._total_layers = 0
         self._checksum_type = ''
         self._checksum = ''
         self._checksums = []
@@ -54,6 +59,14 @@ class Image:
     @property
     def layers(self):
         return self._layers
+
+    @property
+    def load_until_layer(self):
+        return self._load_until_layer
+
+    @property
+    def total_layers(self):
+        return self._total_layers
 
     @property
     def origins(self):
@@ -135,7 +148,7 @@ class Image:
                 return layer
         return None
 
-    def load_image(self):
+    def load_image(self, load_until_layer=0):
         '''Load image metadata
         Currently there is no standard way to do this. For a specific tool,
         Inherit from this class and override this method'''

--- a/tern/formats/default/generator.py
+++ b/tern/formats/default/generator.py
@@ -116,7 +116,7 @@ def print_licenses_only(image_obj_list):
 
 
 class Default(generator.Generate):
-    def generate(self, image_obj_list):
+    def generate(self, image_obj_list, print_inclusive=False):
         '''Generate a default report'''
         report = formats.disclaimer.format(
             version_info=content.get_tool_version())

--- a/tern/formats/generator.py
+++ b/tern/formats/generator.py
@@ -10,6 +10,6 @@ from abc import abstractmethod
 class Generate(metaclass=ABCMeta):
     '''Base class for report plugins'''
     @abstractmethod
-    def generate(self, image_obj_list):
+    def generate(self, image_obj_list, print_inclusive=False):
         '''Format the report according to the plugin style.
         Each subclass is responsible for their own formatting.'''

--- a/tern/formats/html/generator.py
+++ b/tern/formats/html/generator.py
@@ -292,7 +292,7 @@ def get_report_dict(image_obj_list):
 
 
 class HTML(generator.Generate):
-    def generate(self, image_obj_list):
+    def generate(self, image_obj_list, print_inclusive=False):
         '''Given a list of image objects, create a html report
         for the images'''
         report_dict = get_report_dict(image_obj_list)

--- a/tern/formats/json/generator.py
+++ b/tern/formats/json/generator.py
@@ -12,7 +12,7 @@ from tern.formats import generator
 
 
 class JSON(generator.Generate):
-    def generate(self, image_obj_list):
+    def generate(self, image_obj_list, print_inclusive=False):
         '''Given a list of image objects, create a json object string'''
         image_list = []
         for image in image_obj_list:

--- a/tern/formats/spdx/spdxjson/generator.py
+++ b/tern/formats/spdx/spdxjson/generator.py
@@ -84,7 +84,7 @@ def get_document_dict(image_obj, template):
 
 
 class SpdxJSON(generator.Generate):
-    def generate(self, image_obj_list):
+    def generate(self, image_obj_list, print_inclusive=False):
         '''Generate an SPDX document
         WARNING: This assumes that the list consists of one image or the base
         image and a stub image, in which case, the information in the stub

--- a/tern/formats/spdx/spdxtagvalue/generator.py
+++ b/tern/formats/spdx/spdxtagvalue/generator.py
@@ -51,7 +51,7 @@ def get_document_block(image_obj):
 
 
 class SpdxTagValue(generator.Generate):
-    def generate(self, image_obj_list):
+    def generate(self, image_obj_list, print_inclusive=False):
         '''Generate an SPDX document
         WARNING: This assumes that the list consists of one image or the base
         image and a stub image, in which case, the information in the stub

--- a/tern/formats/yaml/generator.py
+++ b/tern/formats/yaml/generator.py
@@ -21,7 +21,7 @@ def print_yaml_report(image):
 
 
 class YAML(generator.Generate):
-    def generate(self, image_obj_list):
+    def generate(self, image_obj_list, print_inclusive=False):
         '''Generate a yaml report'''
         report = formats.disclaimer_yaml.format(
             version_info=get_git_rev_or_version())

--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -47,11 +47,11 @@ def clean_working_dir():
 def generate_report(args, *images):
     '''Generate a report based on the command line options'''
     if args.report_format:
-        return generate_format(images, args.report_format)
-    return generate_format(images, 'default')
+        return generate_format(images, args.report_format, args.print_inclusive)
+    return generate_format(images, 'default', args.print_inclusive)
 
 
-def generate_format(images, format_string):
+def generate_format(images, format_string, print_inclusive):
     '''Generate a report in the format of format_string given one or more
     image objects. Here we will load the required module and run the generate
     function to get back a report'''
@@ -61,7 +61,7 @@ def generate_format(images, format_string):
             name=format_string,
             invoke_on_load=True,
         )
-        return mgr.driver.generate(images)
+        return mgr.driver.generate(images, print_inclusive)
     except NoMatches:
         pass
 

--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -67,6 +67,14 @@ def generate_format(images, format_string, print_inclusive):
 
 
 def report_out(args, *images):
+    for img in images:
+        if args.load_until_layer > img.total_layers and args.load_until_layer != 0:
+            # The actual ignoring is done in docker_image.py
+            # Warning is given here for visibility to user
+            logger.warning(f'Given layer {args.load_until_layer} exceeds total'
+                           + f' number of layers in image ({img.total_layers}).'
+                           + ' Ignoring --layer option and generating report for'
+                           + f' {img.total_layers} total layers')
     report = generate_report(args, *images)
     if not report:
         logger.error("%s not a recognized plugin.", args.report_format)

--- a/tern/utils/cache.py
+++ b/tern/utils/cache.py
@@ -5,15 +5,20 @@
 
 """
 Docker layer cache related modules
-The cache is currently stored in a yaml file called cache.yml
+The cache is currently stored in a json file called cache.json
 It is organized in this way:
-    layer sha:
-        packages:
-           - name:
-             version:
-             license:
-             proj_url:
-        .....
+{
+  "layer sha": {
+    "packages": [
+      {
+        "name": null,
+        "version": null,
+        "license": null,
+        "proj_url": null
+      }
+    ]
+  }
+}
 """
 
 import os


### PR DESCRIPTION
Add -l --layer and -li --layer-inclusive parameters to control SBoM generation for either one selected layer or all layers up to selected layer.

Only default reporter is supported currently. (no error messages when using other reporters, haven't tested them)
Tested against cache & extensions -> no issues on my side (on vagrantbox from this repo)

Initial discussion happened here: #840 