### PR TITLE
Add spdxjson information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Tern is a software package inspection tool for containers. It's written in Pytho
   - [HTML Format](#report-html)
   - [YAML Format](#report-yaml)
   - [SPDX tag-value Format](#report-spdxtagvalue)
+  - [SPDX JSON Format](#report-spdxjson)
 - [Extensions](#extensions)
   - [Scancode](#scancode)
   - [cve-bin-tool](#cve-bin-tool)
@@ -229,9 +230,15 @@ $ tern report -f yaml -i golang:1.12-alpine -o output.yaml
 ```
 
 ## SPDX tag-value Format<a name="report-spdxtagvalue">
-[SPDX](https://spdx.org/) is a format developed by the Linux Foundation to provide a standard way of reporting license information. Many compliance tools are compatible with SPDX. Tern follows the [SPDX specifications](https://spdx.org/specifications) specifically the tag-value format which is the most compatible format with the toolkit the organization provides. The tag-value format is the only SPDX format Tern supports. There are conversion tools available [here](https://github.com/spdx/tools) (some still in development). You can read an overview of the SPDX tag-value specification [here](./docs/spdx-tag-value-overview) and about how Tern maps its properties to the keys mandated by the spec [here](./docs/spdx-tag-value-mapping.md).
+[SPDX](https://spdx.org/) is a format developed by the Linux Foundation to provide a standard way of reporting license information. Many compliance tools are compatible with SPDX. Tern follows the [SPDX specifications](https://spdx.org/specifications). The tag-value format is most compatible with the toolkit the organization provides. There are conversion tools available [here](https://github.com/spdx/tools) (some still in development). You can read an overview of the SPDX tag-value specification [here](./docs/spdx-tag-value-overview) and about how Tern maps its properties to the keys mandated by the spec [here](./docs/spdx-tag-value-mapping.md).
 ```
 $ tern report -f spdxtagvalue -i golang:1.12-alpine -o spdx.txt
+```
+
+## SPDX JSON Format<a name="report-spdxjson">
+The SPDX JSON format contains the same information that an SPDX Tag-value document does. The only difference between these two formats is the way the information is represented. The 'spdxjson' format represents the container information as a collection of key-value pairs. In some cases, the SPDX JSON format may be more interoperable between cloud native compliance tools.
+```
+$ tern report -f spdxjson -i golang:1.12-alpine -o spdx.json
 ```
 
 # Extensions<a name="extensions">


### PR DESCRIPTION
This commit adds SPDX JSON format information to the README now that
there is a new 'spdxjson' format option available.

Signed-off-by: Rose Judge <rjudge@vmware.com>