### PR TITLE
Add File support for JSON SPDX Documents

### DIFF
--- a/tern/formats/spdx/spdx_common.py
+++ b/tern/formats/spdx/spdx_common.py
@@ -126,7 +126,7 @@ def get_file_spdxref(filedata, layer_id):
     We will use a combination of the file name, checksum and layer_id and
     calculate a hash of this string'''
     file_string = filedata.path + filedata.checksum[:7] + layer_id
-    fileid = spdx_formats.get_string_id(file_string)
+    fileid = get_string_id(file_string)
     return 'SPDXRef-{}'.format(fileid)
 
 

--- a/tern/formats/spdx/spdxjson/file_helpers.py
+++ b/tern/formats/spdx/spdxjson/file_helpers.py
@@ -29,7 +29,6 @@ def get_file_dict(filedata, template, layer_id):
     file_dict = {
         'fileName': mapping['FileName'],
         'SPDXID': spdx_common.get_file_spdxref(filedata, layer_id),
-        'fileTypes': [mapping['FileType']],
         'checksums': [{
             'algorithm':
                 spdx_common.get_file_checksum(filedata).split(': ')[0],
@@ -39,6 +38,10 @@ def get_file_dict(filedata, template, layer_id):
         'licenseConcluded': 'NOASSERTION',  # we don't provide this
         'copyrightText': 'NOASSERTION'  # we don't know this
     }
+
+    # Some files may not have a fileType available
+    if mapping['FileType']:
+        file_dict['fileTypes'] = [mapping['FileType']]
 
     if not filedata.licenses:
         file_dict['licenseInfoInFiles'] = ['NONE']

--- a/tern/formats/spdx/spdxjson/file_helpers.py
+++ b/tern/formats/spdx/spdxjson/file_helpers.py
@@ -43,8 +43,11 @@ def get_file_dict(filedata, template, layer_id):
     if not filedata.licenses:
         file_dict['licenseInfoInFiles'] = ['NONE']
     else:
-        file_dict['licenseInfoInFiles'] = spdx_common.get_file_licenses(
-            filedata)
+        file_license_refs = []
+        for lic in spdx_common.get_file_licenses(filedata):
+            # Add the LicenseRef to the list instead of license expression
+            file_license_refs.append(spdx_common.get_license_ref(lic))
+        file_dict['licenseInfoInFiles'] = file_license_refs
 
     # We only add this if there is a notice
     file_notice = spdx_common.get_file_notice(filedata)

--- a/tern/formats/spdx/spdxjson/formats.py
+++ b/tern/formats/spdx/spdxjson/formats.py
@@ -22,7 +22,7 @@ creator = 'Tool: tern-{version}'
 created = '{timestamp}'
 
 
-# Relationship Formatting
+# Dictionary Formatting
 def get_relationship_dict(element_id, related_element_id, relationship_type):
     '''Given two SPDX element IDs and their relationship type, return a
     dictionary that represents the relationship. Assume that the element_id
@@ -36,4 +36,17 @@ def get_relationship_dict(element_id, related_element_id, relationship_type):
         "spdxElementId": element_id,
         "relatedSpdxElement": related_element_id,
         "relationshipType": relationship_type
+    }
+
+
+def get_extracted_text_dict(extracted_text, license_ref):
+    '''Given a plain text license string and the corresponding license_ref,
+    return a dictionary that describes the key-value pair:
+        {
+            "extractedText" : "extracted_text"
+            "licenseId": "license_ref"
+        }'''
+    return {
+        "extractedText": extracted_text,
+        "licenseId": license_ref
     }

--- a/tern/formats/spdx/spdxjson/generator.py
+++ b/tern/formats/spdx/spdxjson/generator.py
@@ -75,6 +75,11 @@ def get_document_dict(image_obj, template):
     if files:
         docu_dict['files'] = files
 
+    # Add package and file extracted license texts, if they exist
+    extracted_texts = mhelpers.get_image_extracted_licenses(image_obj)
+    if extracted_texts:
+        docu_dict['hasExtractedLicensingInfos'] = extracted_texts
+
     return docu_dict
 
 

--- a/tern/formats/spdx/spdxjson/image_helpers.py
+++ b/tern/formats/spdx/spdxjson/image_helpers.py
@@ -11,6 +11,32 @@ from tern.formats.spdx import spdx_common
 from tern.formats.spdx.spdxjson import formats as json_formats
 
 
+def get_image_extracted_licenses(image_obj):
+    '''Given an image_obj, return a unique list of extractedText dictionaries
+    that contain all the file and package license key-value pairs for a
+    LicenseRef and its corresponding plain text. The dictionaries will
+    contain the following information:
+        {
+            "extractedText": "Plain text of license",
+            "licenseId": "Corresponding LicenseRef"
+        }'''
+
+    unique_licenses = set()
+    for layer in image_obj.layers:
+        # Get all of the unique file licenses, if they exist
+        unique_licenses.update(spdx_common.get_layer_licenses(layer))
+        # Next, collect any package licenses not already accounted for
+        for package in layer.packages:
+            if package.pkg_license:
+                unique_licenses.add(package.pkg_license)
+    extracted_texts = []
+    for lic in list(unique_licenses):
+        extracted_texts.append(json_formats.get_extracted_text_dict(
+            extracted_text=lic, license_ref=spdx_common.get_license_ref(
+                lic)))
+    return extracted_texts
+
+
 def get_image_layer_relationships(image_obj):
     '''Given an image object, return a list of dictionaries describing the
     relationship between each layer "package" and the image "package".

--- a/tern/formats/spdx/spdxjson/layer_helpers.py
+++ b/tern/formats/spdx/spdxjson/layer_helpers.py
@@ -141,9 +141,14 @@ def get_layer_dict(layer_obj, template, image_loc=''):
         layer_dict['comment'] = layer_pkg_comment
 
     # Include layer licenses from files only if they exist
+    # List will be blank if no filedata information exists
     layer_licenses = spdx_common.get_layer_licenses(layer_obj)
+    layer_license_refs = []
     if layer_licenses:
-        layer_dict['licenseInfoFromFiles'] = layer_licenses
+        # Use the layer LicenseRef in the list instead of license expression
+        for lic in layer_licenses:
+            layer_license_refs.append(spdx_common.get_license_ref(lic))
+        layer_dict['licenseInfoFromFiles'] = layer_license_refs
 
     return layer_dict
 

--- a/tern/formats/spdx/spdxtagvalue/file_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/file_helpers.py
@@ -7,7 +7,6 @@
 File level helpers for SPDX tag-value document generator
 """
 
-from tern.formats.spdx.spdxtagvalue import formats as spdx_formats
 from tern.formats.spdx import spdx_common
 
 
@@ -36,7 +35,7 @@ def get_license_info_block(filedata):
     else:
         for lic in spdx_common.get_file_licenses(filedata):
             block = block + 'LicenseInfoInFile: {}'.format(
-                spdx_formats.get_license_ref(lic)) + '\n'
+                spdx_common.get_license_ref(lic)) + '\n'
     return block
 
 

--- a/tern/formats/spdx/spdxtagvalue/image_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/image_helpers.py
@@ -64,7 +64,7 @@ def get_image_file_license_block(image_obj):
     licenses = set()
     for layer in image_obj.layers:
         if layer.files_analyzed:
-            for lic in lhelpers.get_layer_licenses(layer):
+            for lic in spdx_common.get_layer_licenses(layer):
                 licenses.add(lic)
     for lic in licenses:
         block += spdx_formats.license_id.format(

--- a/tern/formats/spdx/spdxtagvalue/layer_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/layer_helpers.py
@@ -68,7 +68,7 @@ def get_package_license_info_block(layer_obj):
         if licenses:
             for lic in licenses:
                 block += 'PackageLicenseInfoFromFiles: {}\n'.format(
-                    spdx_formats.get_license_ref(lic))
+                    spdx_common.get_license_ref(lic))
         else:
             block = 'PackageLicenseInfoFromFiles: NONE\n'
     return block


### PR DESCRIPTION
A previous commit, bca41a2, added support for a SPDX JSON format.
While that commit *does* produce technically valid JSON documents,
it, embarrassingly, wasn't thoroughly tested in conjunction with a
file-level external  analysis tool like scancode.

This PR adds previously missing functionality that is
necessary for Tern to produce SPDX JSON documents that
successfully validate when file level information is available.
In particular, these commit do the following:

1) Updates a few spdxtagvalue file-related functions that were
referencing the wrong location of a common function (oversight from 
some refactoring done in commit 87f1c29.)

2) Uses the LicenseRef for File licenses in the document. File
level licenses were previously appearing as plain text
(i.e "Public Domain" instead of a unique SPDX LicenseRef).
The plain text was causing validation errors in some cases. 

3) Adds extractedText information to the
SPDX JSON document. This is necessary to provide a copy of the
actual text of the licenses reference extracted from the file
that is associated with the License Identifier and aids in future
analysis.

4) Fixes the spdxjson format to only include the fileType value
in the JSON document if the value is a valid enum constant.