### PR TITLE
Set SPDX PackageDownloadLocation to valid value

### DIFF
--- a/tern/formats/spdx/spdx.py
+++ b/tern/formats/spdx/spdx.py
@@ -26,5 +26,4 @@ class SPDX(Template):
 
     def image(self):
         return {'name': 'PackageName',
-                'tag': 'PackageVersion',
-                'repotag': 'PackageDownloadLocation'}
+                'tag': 'PackageVersion'}

--- a/tern/formats/spdx/spdxjson/generator.py
+++ b/tern/formats/spdx/spdxjson/generator.py
@@ -63,7 +63,7 @@ def get_document_dict(image_obj, template):
     }
 
     # Add list of layer dictionaries to packages list
-    docu_dict['packages'] += lhelpers.get_layers_list(image_obj, template)
+    docu_dict['packages'] += lhelpers.get_layers_list(image_obj)
 
     # Add list of package dictionaries to packages list, if they exist
     pkgs_dict_list = phelpers.get_packages_list(image_obj, template)

--- a/tern/formats/spdx/spdxjson/image_helpers.py
+++ b/tern/formats/spdx/spdxjson/image_helpers.py
@@ -80,7 +80,7 @@ def get_image_dict(image_obj, template):
         'name': mapping['PackageName'],
         'SPDXID': spdx_common.get_image_spdxref(image_obj),
         'versionInfo': mapping['PackageVersion'],
-        'downloadLocation': mapping['PackageDownloadLocation'],
+        'downloadLocation': 'NOASSERTION',  # always NOASSERTION
         'filesAnalyzed': 'false',  # always false
         'licenseConcluded': 'NOASSERTION',  # always NOASSERTION
         'licenseDeclared': 'NOASSERTION',  # always NOASSERTION

--- a/tern/formats/spdx/spdxjson/layer_helpers.py
+++ b/tern/formats/spdx/spdxjson/layer_helpers.py
@@ -74,9 +74,8 @@ def get_layer_package_comment(layer_obj):
 
 
 def get_layer_file_data_list(layer_obj):
-    '''Given a layer object and the template object, return the SPDX list of
-    of file refs in the layer. Return an empty string if the files are not
-    analyzed'''
+    '''Given a layer object return the SPDX list of file refs in the layer.
+    Return an empty string if the files are not analyzed'''
     layer_lics = []
     if layer_obj.files_analyzed:
         layer_checksum = spdx_common.get_layer_checksum(layer_obj)
@@ -95,23 +94,16 @@ def get_layer_file_data_list(layer_obj):
     return layer_lics
 
 
-def get_layer_dict(layer_obj, template, image_loc=''):
-    '''Given an layer object and its SPDX template mapping, return a SPDX
-    JSON/dictionary representation of the layer. An image layer in
-    SPDX behaves like a Package. The analyzed files will go in a separate
-    dictionary for the JSON document.
+def get_layer_dict(layer_obj):
+    '''Given an layer object, return a SPDX JSON/dictionary representation
+    of the layer. An image layer in SPDX behaves like a Package. The analyzed
+    files will go in a separate dictionary for the JSON document.'''
 
-    We also pass the image location as optional for where the layers were
-    downloaded from. Registries can be implemented as distributed storage
-    or images can be stored as whole tarballs. Either way, the layer
-    would be downloaded along with the image.'''
-    mapping = layer_obj.to_dict(template)
     layer_dict = {
         'name': os.path.basename(layer_obj.tar_file),
         'SPDXID': spdx_common.get_layer_spdxref(layer_obj),
         'fileName': layer_obj.tar_file,
-        'downloadLocation': mapping['PackageFileName'] if image_loc
-        else 'NOASSERTION',
+        'downloadLocation': 'NONE',
         'filesAnalyzed': 'true' if layer_obj.files_analyzed else 'false',
         'checksums': [{
             'algorithm':
@@ -153,19 +145,16 @@ def get_layer_dict(layer_obj, template, image_loc=''):
     return layer_dict
 
 
-def get_layers_list(image_obj, template):
-    '''Given an image object and the template object for SPDX, return a list
-    of SPDX dictionary representations of each of the layers in the image.
-    Each layer will be represented as a package and hence follows the JSON
-    spec for packages.
+def get_layers_list(image_obj):
+    '''Given an image object for SPDX, return a list of SPDX dictionary
+    representations of each of the layers in the image. Each layer will be
+    represented as a package and hence follows the JSON spec for packages.
         name
         versionInfo
         downloadLocation'''
     layer_dicts = []
-    mapping = image_obj.to_dict(template)
     for layer in image_obj.layers:
         # Create a list of dictionaries. Each dictionary represents one
         # layer as a SPDX package
-        layer_dicts.append(get_layer_dict(layer, template,
-                                          mapping['PackageDownloadLocation']))
+        layer_dicts.append(get_layer_dict(layer))
     return layer_dicts

--- a/tern/formats/spdx/spdxtagvalue/image_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/image_helpers.py
@@ -89,9 +89,8 @@ def get_image_block(image_obj, template):
     block += 'SPDXID: {}\n'.format(spdx_common.get_image_spdxref(image_obj))
     # Package Version
     block += 'PackageVersion: {}\n'.format(mapping['PackageVersion'])
-    # Package Download Location
-    block += 'PackageDownloadLocation: {}\n'.format(
-        mapping['PackageDownloadLocation'])
+    # Package Download Location (always NOASSERTION)
+    block += 'PackageDownloadLocation: NOASSERTION\n'
     # Files Analyzed (always false)
     block += 'FilesAnalyzed: false\n'
     # Concluded Package License (always NOASSERTION)
@@ -108,8 +107,7 @@ def get_image_block(image_obj, template):
     block += '\n'
     # Describe each layer 'package' that the image contains
     for index, layer in enumerate(image_obj.layers):
-        block += lhelpers.get_layer_block(
-            layer, template, mapping['PackageDownloadLocation']) + '\n'
+        block += lhelpers.get_layer_block(layer, template) + '\n'
         # print layer relationship to previous layer if there is one
         if index != 0:
             block += lhelpers.get_layer_prereq(

--- a/tern/formats/spdx/spdxtagvalue/layer_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/layer_helpers.py
@@ -98,31 +98,22 @@ def get_layer_file_data_block(layer_obj, template):
     return block
 
 
-def get_layer_block(layer_obj, template, image_loc=''):
+def get_layer_block(layer_obj, template):
     '''Given a layer object and its SPDX template mapping, return a SPDX
     document block for the layer. An image layer in SPDX behaves like a
     Package with relationships to the Packages within it. If the files
     are analyzed though, we just list the files in the block. The mapping
     should have keys:
-        PackageFileName
-    We also pass the image location as optional for where the layers were
-    downloaded from. Registries can be implemented as distributed storage
-    or images can be stored as whole tarballs. Either way, the layers
-    would be downloaded along with the image.'''
+        PackageFileName'''
     block = ''
-    mapping = layer_obj.to_dict(template)
     # Package Name
     block += 'PackageName: {}\n'.format(os.path.basename(layer_obj.tar_file))
     # Package SPDXID
     block += 'SPDXID: {}\n'.format(spdx_common.get_layer_spdxref(layer_obj))
     # Package File Name
     block += 'PackageFileName: {}\n'.format(layer_obj.tar_file)
-    # Package Download Location
-    if image_loc:
-        block += 'PackageDownloadLocation: {}\n'.format(
-            mapping['PackageFileName'])
-    else:
-        block += 'PackageDownloadLocation: NONE\n'
+    # Package Download Location (always NONE for layers)
+    block += 'PackageDownloadLocation: NONE\n'
     # Files Analyzed
     if layer_obj.files_analyzed:
         # we need a package verification code


### PR DESCRIPTION
Currently, the spdxtagvalue and spdxjson formats use the image repotag
as the "package" download location value for images and the location of the
layer tarball as the "package download location for layers when producing SPDX
documents. This is incorrect in accordance with the 2.2 spec, however, as the spec
only supports either NONE/NOASSERTION or "referencing locations in version
control systems such as Git, Mercurial, Subversion and Bazaar, and specifies
the type of VCS tool using url prefixes: git+, hg+, bzr+, svn+ and specific
transport schemes such as SSH or HTTPS."

This commit sets the PackageDownloadLocation to NOASSERTION for
image 'packages' and NONE for image_layer 'packages' for both the
spdxtagvalue and spdxjson formats instead of using the repotag and
location of the tarball in the image, respectively.

Resolves #855 