### PR TITLE
Make scancode use more processes

### DIFF
--- a/tern/extensions/scancode/executor.py
+++ b/tern/extensions/scancode/executor.py
@@ -108,7 +108,11 @@ def collect_layer_data(layer_obj):
     files = []
     packages = []
     # run scancode against a directory
-    command = 'scancode -ilpcu --quiet --timeout 300 --json -'
+    try:
+        processes = len(os.sched_getaffinity(0))
+        command = "scancode -ilpcu --quiet --timeout 300 -n {} --json -".format(processes)
+    except (AttributeError, NotImplementedError):
+        command = "scancode -ilpcu --quiet --timeout 300 --json -"
     full_cmd = get_filesystem_command(layer_obj, command)
     origin_layer = 'Layer {}'.format(layer_obj.layer_index)
     result, error = rootfs.shell_command(True, full_cmd)


### PR DESCRIPTION
Use len(os.sched_getaffinity(0)) to respect possible restrictions set on
CPU usage. User can limit the CPU usage of scancode with taskset on
linux as scancode will use all available cores.

The downside of this is that it is UNIX only approach, yet using
cross-platform approach would need additional dependency- the most
popular being psutil.

If during configuration time, when Python core is built, compilation of
code with sched_setaffinity will fail and HAVE_SCHED_SETAFFINITY is not
set, the call will not be avaliable and tern should fall-back to calling
scancode without -n option to respect it's defaults.

```
Tested on Vagrant VM using Vagrantfile from the repository after:
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -12,7 +12,7 @@
 # Customize the amount of memory on the VM:
 VM_MEMORY = 4 * 1024
 # Customize amount of cores for the VM:
-VM_CPUS = 2
+VM_CPUS = 4
 
 Vagrant.configure("2") do |config|
   # The most common configuration options are documented and commented below.
```

For reference, lscpu output on the VM:
Architecture:        x86_64
CPU op-mode(s):      32-bit, 64-bit
Byte Order:          Little Endian
CPU(s):              4
On-line CPU(s) list: 0-3
Thread(s) per core:  1
Core(s) per socket:  1
Socket(s):           4
NUMA node(s):        1
Vendor ID:           GenuineIntel
CPU family:          6
Model:               94
Model name:          Intel Core Processor (Skylake, IBRS)
Stepping:            3
CPU MHz:             3407.980
(...)

on master:
$ time python3 -m tern -c report -x scancode -f yaml -o golang_scancode.yml -i golang:latest > golang_scancode.log 2>&1

real	189m17.804s
user	188m40.270s
sys	0m31.676s

after the patch:
$ time python3 -m tern -c report -x scancode -f yaml -o golang_scancode.yml -i golang:latest > golang_scancode.log 2>&1

real	54m15.168s
user	206m58.331s
sys	0m30.218s