### PR TITLE
Update tests to refer to the main branch

### DIFF
--- a/ci/evaluate_docs.py
+++ b/ci/evaluate_docs.py
@@ -23,7 +23,7 @@ except GitCommandError:
 repo.git.fetch('upstream')
 
 hcommit = repo.head.commit
-diff = hcommit.diff('upstream/master')
+diff = hcommit.diff('upstream/main')
 
 if not diff:
     sys.exit(0)

--- a/ci/test_commit_message.py
+++ b/ci/test_commit_message.py
@@ -67,9 +67,9 @@ if __name__ == '__main__':
     except GitCommandError:
         pass
     repo.git.fetch('upstream')
-    # Will return commit IDs differentiating HEAD and master
-    commitstr = repo.git.rev_list('HEAD', '^upstream/master', no_merges=True)
-    # If we are on the main project's master branch then there will be no
+    # Will return commit IDs differentiating HEAD and main
+    commitstr = repo.git.rev_list('HEAD', '^upstream/main', no_merges=True)
+    # If we are on the project's main branch then there will be no
     # difference and the result will be an empty string
     # So we will not proceed if there is no difference
     if commitstr:

--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -22,7 +22,7 @@ except GitCommandError:
 repo.git.fetch('upstream')
 
 hcommit = repo.head.commit
-diff = hcommit.diff('upstream/master')
+diff = hcommit.diff('upstream/main')
 
 changes = []
 for d in diff:


### PR DESCRIPTION
Since the branch "master" was renamed to "main", we update the
commit message, docs test, and testing based on files touched to
refer to the remote's main branch.

Signed-off-by: Nisha K <nishak@vmware.com>