### PR TITLE
Fix tests for human readable id creation

### DIFF
--- a/tern/classes/image.py
+++ b/tern/classes/image.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 from tern.classes.origins import Origins
@@ -10,9 +10,9 @@ from tern.utils.general import prop_names
 class Image:
     '''A representation of the image to be analyzed
     attributes:
-        image_id: this is a unique identifier for the image - for OCI spec
-        this could be the digest. For now this is the sha256sum of the
-        config.json
+        repotag: The image's repository and tag or the repository and
+        digest. However, in order to be compatible with any future image
+        identification scheme, this can be any string.
         manifest: the json object representing the image manifest
         config: the image config metadata
         layers: list of layer objects in the image

--- a/tests/test_class_image.py
+++ b/tests/test_class_image.py
@@ -16,7 +16,7 @@ class TestClassImage(unittest.TestCase):
 
     def setUp(self):
         '''Test a generic Image class'''
-        self.image1 = Image('1234abcd')
+        self.image1 = Image('repo:tag')
         self.image2 = TestImage('5678efgh')
         self.image3 = TestImage('f380a61e')
 
@@ -26,7 +26,7 @@ class TestClassImage(unittest.TestCase):
         del self.image3
 
     def testInstance(self):
-        self.assertEqual(self.image1.repotag, '1234abcd')
+        self.assertEqual(self.image1.repotag, 'repo:tag')
         self.assertFalse(self.image1.name)
         self.assertFalse(self.image1.manifest)
         self.assertFalse(self.image1.tag)
@@ -76,10 +76,18 @@ class TestClassImage(unittest.TestCase):
         self.assertEqual(len(dict2['image.layers'][0]['layer.packages']), 2)
 
     def testGetHumanReadableId(self):
-        self.assertEqual(self.image1.get_human_readable_id(), '1234abcd')
+        self.image1.name = 'repo'
+        self.image1.tag = 'tag'
+        self.assertEqual(self.image1.get_human_readable_id(), 'repo-tag')
         self.image2.load_image()
+        self.image2.set_checksum('sha256', '12345abcde')
         self.assertEqual(
-            self.image2.get_human_readable_id(), '5678efgh-testimage-testtag')
+            self.image2.get_human_readable_id(),
+            'testimage-testtag')
+        self.image1.tag = ''
+        self.image1.set_checksum('sha256', '12345abcde')
+        self.assertEqual(
+            self.image1.get_human_readable_id(), 'repo-12345abcde')
 
     def testSetImageImport(self):
         self.image1.load_image()


### PR DESCRIPTION
The Image class now takes a repotag string of the form:
'image:tag' or 'image@hash:digest'. This commit updates the
documentation for the class and the corresponding test.

Since the human readable id is based on repo name and a repo tag,
we update the tests to check if the appropriate string is returned
For different combination of settings.

Signed-off-by: Nisha K <nishak@vmware.com>