### PR TITLE
Enabled SPDX document validation for CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -60,11 +60,15 @@ jobs:
           python-version: '3.7'
       - name: Setup
         run: |
-          sudo apt-get install -y attr
+          sudo apt-get update && sudo apt-get install -y attr openjdk-8-jdk-headless maven
           pip install --upgrade pip
           pip install GitPython~=2.1
           pip install .
           docker pull photon:3.0 && docker save photon:3.0 > photon.tar
+          # build SPDX validation tool from source
+          git clone https://github.com/spdx/tools-java.git && cd tools-java
+          export JAVA_HOME=$(readlink -f /usr/bin/javac | sed "s:/bin/javac::")
+          mvn clean install && cd ..
       - name: Test Changes
         run: python ci/test_files_touched.py
   Test_Coverage:

--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -92,11 +92,17 @@ test_suite = {
         'tern report -f yaml -i photon:3.0',
         'tern report -f json -i photon:3.0',
         'tern report -f spdxtagvalue -i photon:3.0',
+        'tern report -f spdxjson -i photon:3.0',
         'tern report -d samples/alpine_python/Dockerfile',
         'tern report -f html -i photon:3.0'],
     # tern/formats/spdx
     re.compile('tern/formats/spdx'): [
-        'tern report -f spdxtagvalue -i photon:3.0'],
+        'tern report -f spdxtagvalue -i photon:3.0 -o spdx.spdx && ' \
+        'java -jar tools-java/target/tools-java-*-jar-with-dependencies.jar '\
+        'Verify spdx.spdx',
+        'tern report -f spdxjson -i photon:3.0 -o spdx.json && ' \
+        'java -jar tools-java/target/tools-java-*-jar-with-dependencies.jar '\
+        'Verify spdx.json'],
     # tern/tools
     re.compile('tern/tools'):
     ['tern report -i golang:alpine'],


### PR DESCRIPTION
As development increases for Tern, it is getting harder to maintain the
generation of valid SPDX documents for container images. This commit
enables CI checks for the SPDX documents that Tern produces to make sure
the documents are valid.

Resolves #713

Signed-off-by: Rose Judge <rjudge@vmware.com>