### PR TITLE
Fix for not retrieving cached notices

### DIFF
--- a/tern/analyze/common.py
+++ b/tern/analyze/common.py
@@ -69,6 +69,7 @@ def load_from_cache(layer, redo=False):
                 'extension_info', {})
             load_packages_from_cache(layer)
             load_files_from_cache(layer)
+            load_notices_from_cache(layer)
             loaded = True
         else:
             # if the hash is not present in the cache, load that data from the

--- a/tern/report/formats.py
+++ b/tern/report/formats.py
@@ -65,9 +65,8 @@ invoking_snippet_commands = '''Invoking commands from ''' \
     '''command_lib/snippets.yml'''
 ignored = '''\nIgnored Commands:'''
 unrecognized = '''\nUnrecognized Commands:'''
-os_style_guess = '''Found {package_manager} package manager with '''\
-    '''{package_format} package format. Possible OS(es) for this layer '''\
-    '''might be: {os_list}'''
+os_style_guess = '''Found {package_manager} in filesystem. ''' \
+    '''Possible OS(es) might be: {os_list}'''
 os_release = '''Found '{os_style}' in /etc/os-release.'''
 
 # report formatting for dockerfiles


### PR DESCRIPTION
The first commit saves the found OS and package
format to the specific layer so they are available to
all format generators.

The second commit loads the layer notices from the
cache.