### PR TITLE
Bug fix for images that don't have repos or tags

### DIFF
--- a/tern/analyze/default/container/run.py
+++ b/tern/analyze/default/container/run.py
@@ -32,11 +32,13 @@ def extract_image(args):
         image_attrs = docker_api.dump_docker_image(args.docker_image)
         if image_attrs:
             # repo name and digest is preferred, but if that doesn't exist
-            # the repo name and tag will do
-            if image_attrs['RepoDigests']:
-                image_string = image_attrs['RepoDigests'][0]
+            # the repo name and tag will do. If neither exist use repo Id.
+            if image_attrs['Id']:
+                image_string = image_attrs['Id']
             if image_attrs['RepoTags']:
                 image_string = image_attrs['RepoTags'][0]
+            if image_attrs['RepoDigests']:
+                image_string = image_attrs['RepoDigests'][0]
             return image_string
         logger.critical("Cannot extract Docker image")
     if args.raw_image:


### PR DESCRIPTION
Tern looks at Docker Image metadata to find the repo name and digest or
the repo name and tag and includes this information in the data model as
well as the final output report. When `RepoDigests` or `RepoTags`
metadata is not available, Tern fails because it tries to return a
variable, image_string, that is not set in the extract_image() function
in tern/analyze/default/container/run.py. This commit does two things:

1) Fixes the issue by assigning image_string to the image `Id` property
when `RepoDigests` or `RepoTags` metadata is not available. The image Id
will of the form `digest_type:digest`.

2) Changes the order of assignment for the image_string variable so that
Tern will use repo name and digest (`RepoDigests`) when possible. If not
available in the image metadata, Tern will use the image name and tag
second (`RepoTags`), followed by the repo `Id` if repo digests and tags
are not available.

Resolves #874

Signed-off-by: Rose Judge <rjudge@vmware.com>