### PR TITLE
Fix duplicate package reporting for alpine images

### DIFF
--- a/tern/analyze/default/command_lib/base.yml
+++ b/tern/analyze/default/command_lib/base.yml
@@ -128,7 +128,7 @@ apk:
         container:
           # use double quotes when using awk
           - "pkgs=`apk info 2>/dev/null`"
-          - "for p in $pkgs; do lic=`apk info $p 2>/dev/null | head -1 | awk '{print $1}'`; echo $lic | awk -F \"${p}-\" '{print $2}'; done"
+          - "for p in $pkgs; do lic=`apk info $p 2>/dev/null | head -1 | awk '{print $1}'`; echo $lic | sed -e \"s/^$p-//\"; done"
     delimiter: "\n"
   licenses:
     invoke:


### PR DESCRIPTION
The apk package version collection utility in base.yml was not correctly
parsing version strings for the "libstdc++" package name (and possibly
others with non-alpha numeric characters). This was causing Tern to
report an empty version string for the libstdc++ package which led to
missing version strings and incorrect layer packages in the output
report. This commit slightly tweaks the package version collection
script to use sed instead of awk in order to properly collect and
report the package version information.

Resolves #881

Signed-off-by: Rose Judge <rjudge@vmware.com>