### PR TITLE
Add initial support for distroless containers

### DIFF
--- a/tern/analyze/default/command_lib/base.yml
+++ b/tern/analyze/default/command_lib/base.yml
@@ -440,3 +440,33 @@ go:
         container:
           - "go list -m all | tail -n +2 | cut -d ' ' -f 1"
     delimiter: "\n"
+# distroless------------------------------------------------------------------
+distroless:
+  pkg_format: 'deb'
+  os_guess:
+    - 'Distroless'
+  path:
+    - 'var/lib/dpkg/status.d/'
+  names:
+    invoke:
+      1:  
+        host:
+          - "files=`ls var/lib/dpkg/status.d`"
+          - "for f in $files; do grep -oP '^Package: \\K.*$' var/lib/dpkg/status.d/$f; done"
+    delimiter: "\n"
+  versions:
+    invoke:
+      1:  
+        host:
+          - "files=`ls var/lib/dpkg/status.d`"
+          - "for f in $files; do grep -oP '^Version: \\K.*$' var/lib/dpkg/status.d/$f; done"
+    delimiter: "\n"
+  copyrights:
+    invoke:
+      1:
+        host:
+          - "files=`ls var/lib/dpkg/status.d`"
+          - "pkgs=`for f in $files; do grep -oP '^Package: \\K.*$' var/lib/dpkg/status.d/$f; done`"
+          - "for p in $pkgs; do /bin/cat /usr/share/doc/$p/copyright; echo LICF; done"
+    delimiter: "LICF"
+  proj_urls: {}

--- a/tern/analyze/default/command_lib/command_lib.py
+++ b/tern/analyze/default/command_lib/command_lib.py
@@ -7,6 +7,7 @@
 Invoking commands in the command library
 """
 
+import copy
 import logging
 import os
 import yaml
@@ -57,7 +58,7 @@ def get_base_listing(key):
     '''Given the key listing in base.yml, return the dictionary'''
     listing = {}
     if key in command_lib['base'].keys():
-        listing = command_lib['base'][key]
+        listing = copy.deepcopy(command_lib['base'][key])
     else:
         logger.warning("%s", errors.no_listing_for_base_key.format(
             listing_key=key))

--- a/tern/analyze/default/container/multi_layer.py
+++ b/tern/analyze/default/container/multi_layer.py
@@ -68,6 +68,9 @@ def fresh_analysis(image_obj, curr_layer, prereqs, options):
                     image_obj.layers[curr_layer], command, prereqs)
         rootfs.undo_mount()
         rootfs.unmount_rootfs()
+    # distroless images do not have a command list
+    elif image_obj.layers[0].os_guess == 'Distroless':
+        core.execute_distroless(image_obj.layers[curr_layer], prereqs)
 
 
 def analyze_subsequent_layers(image_obj, shell, master_list, options):

--- a/tern/analyze/default/container/single_layer.py
+++ b/tern/analyze/default/container/single_layer.py
@@ -146,6 +146,9 @@ def analyze_first_layer(image_obj, master_list, options):
             # unmount
             rootfs.undo_mount()
             rootfs.unmount_rootfs()
+        # distroless images do not have a shell
+        elif prereqs.binary == 'distroless':
+            core.execute_distroless(image_obj.layers[0], prereqs)
     # populate the master list with all packages found in the first layer
     for p in image_obj.layers[0].packages:
         master_list.append(p)

--- a/tern/formats/spdx/spdxjson/layer_helpers.py
+++ b/tern/formats/spdx/spdxjson/layer_helpers.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-7 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause

--- a/tern/report/content.py
+++ b/tern/report/content.py
@@ -82,6 +82,10 @@ def print_invoke_list(info_dict, info):
                 report = report + formats.invoke_in_container
                 for snippet in info_dict[info]['invoke'][step]['container']:
                     report = report + '\t' + snippet + '\n'
+            elif 'host' in info_dict[info]['invoke'][step]:
+                report = report + formats.invoke_on_host
+                for snippet in info_dict[info]['invoke'][step]['container']:
+                    report = report + '\t' + snippet + '\n'
     else:
         for value in info_dict[info]:
             report = report + ' ' + value

--- a/tern/utils/host.py
+++ b/tern/utils/host.py
@@ -1,0 +1,11 @@
+import os
+
+from tern.analyze.default.command_lib import command_lib
+
+
+def check_shell():
+    """Check if any shell binary is available on the host"""
+    for shell in command_lib.command_lib["common"]["shells"]:
+        if os.path.exists(shell):
+            return shell
+    return ""

--- a/tern/utils/rootfs.py
+++ b/tern/utils/rootfs.py
@@ -244,6 +244,17 @@ def run_chroot_command(command_string, shell):
             1, cmd=command_string, output=None, stderr=e.stderr)
 
 
+def run_host_command(command_string, shell):
+    '''Run the command string on the host'''
+    try:
+        result = root_command([], shell, '-c', command_string)
+        return result
+    except subprocess.CalledProcessError as e:
+        logger.warning("Error executing command in chroot")
+        raise subprocess.CalledProcessError(
+            1, cmd=command_string, output=None, stderr=e.stderr)
+
+
 def undo_mount():
     '''Unmount proc, sys, and dev directories'''
     rootfs_path = os.path.join(get_working_dir(), constants.mergedir)


### PR DESCRIPTION
This PR adds support for extracting package information from [distroless containers](https://github.com/GoogleContainerTools/distroless).

As-is, I'm able to extract package names and versions from [all current tags](https://gcr.io/v2/distroless/tags/list). I'm also able to extract copyright information, but not had success mapping it to licenses. Please see the logs for:
- [gcr.io/distroless/base:latest](https://gist.github.com/JamieMagee/d9cf1ca579b230db504186cbae816f2d#file-distroless-base-latest-log)
- [gcr.io/distroless/dotnet:latest](https://gist.github.com/JamieMagee/d9cf1ca579b230db504186cbae816f2d#file-distroless-dotnet-latest-log)
- [gcr.io/distroless/python3:debug](https://gist.github.com/JamieMagee/d9cf1ca579b230db504186cbae816f2d#file-distroless-python3-debug-log)

Closes #864