### PR TITLE
Fix for docker registries hosted on different port

### DIFF
--- a/tern/utils/general.py
+++ b/tern/utils/general.py
@@ -306,4 +306,9 @@ def parse_image_string(image_string):
                 'tag': '',
                 'digest_type': tokens[1],
                 'digest': tokens[2]}
+    if len(tokens) == 4:
+        return {'name': tokens[0] + ":" + tokens[1],
+                'tag': '',
+                'digest_type': tokens[2],
+                'digest': tokens[3]}
     return None

--- a/tests/test_util_general.py
+++ b/tests/test_util_general.py
@@ -34,6 +34,8 @@ class TestUtilGeneral(unittest.TestCase):
         resizer = 'gcr.io/google-containers/addon-resizer:2.3'
         etcd = ('bitnami/etcd@sha256:35862e29b27efd97cdf4a1fc79abc1341feac556'
                 '32e4256b02e6cfee9a4b6455')
+        nexus = ('nexus3.onap.org:10001/onap/so/so-oof-adapter@sha256:d7e1f739ba732c'
+                 '853a638f9c90becd5e0f8d313c8d506567b0b83ac38a1d53cb')
         self.assertEqual(general.parse_image_string(hello),
                          {'name': 'hello-world',
                           'tag': '',
@@ -60,6 +62,12 @@ class TestUtilGeneral(unittest.TestCase):
                           'digest_type': 'sha256',
                           'digest': ('35862e29b27efd97cdf4a1fc79abc1341fe'
                                      'ac55632e4256b02e6cfee9a4b6455')})
+        self.assertEqual(general.parse_image_string(nexus),
+                         {'name': 'nexus3.onap.org:10001/onap/so/so-oof-adapter',
+                          'tag': '',
+                          'digest_type': 'sha256',
+                          'digest': ('d7e1f739ba732c853a638f9c90becd5e0f8'
+                                     'd313c8d506567b0b83ac38a1d53cb')})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a hot-fix, I didn't dive into how the docker images can be named and it *might* not be correct solution. If someone could help me with listing possible solutions I can adjust the PR.

Some comments should also be added, but I'd prefer to get some input first and adjust it later (as I can use it for ONAP for now)