### PR TITLE
Fix error message when no created_by info for layers

### DIFF
--- a/tern/analyze/default/default_common.py
+++ b/tern/analyze/default/default_common.py
@@ -115,8 +115,7 @@ def get_commands_from_metadata(image_layer):
                     origin_layer, Notice(msg, 'warning'))
             return command_list
     image_layer.origins.add_notice_to_origins(
-        origin_layer, Notice(errors.unknown_content.format(
-            files=command_line), 'warning'))
+        origin_layer, Notice(errors.no_layer_created_by, 'warning'))
     return []
 
 

--- a/tern/report/errors.py
+++ b/tern/report/errors.py
@@ -81,6 +81,7 @@ no_running_docker_container = '''Cannot invoke commands in a container '''\
 cannot_find_image = '''Cannot find image {imagetag} locally or from remote '''\
     '''registry.\n'''
 empty_layer = '''Empty layer. Nothing to do.\n'''
+no_layer_created_by = "No created_by information for layer."
 
 # not error messages but stuff for the logger
 no_base_image = '''Base image is FROM scratch. Skipping to build'''


### PR DESCRIPTION
Squashed images do not contain `created_by` information for layers.
Running Tern on a squashed image exposed a bug where Tern tries
to report on the `created_by` information of a layer even though the
information is not available. To resolve this fix, this commit adds a
new error message, `no_layer_created_by`, that alerts the user that
layer creation info is not available and uses this in the output
report.

Resolves #838

Signed-off-by: Rose Judge <rjudge@vmware.com>