### PR TITLE
Refactor: pass arguments as a single object

### DIFF
--- a/tern/analyze/default/container/image.py
+++ b/tern/analyze/default/container/image.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 """
@@ -43,7 +43,7 @@ def load_full_image(image_tag_string, load_until_layer=0):
     return test_image
 
 
-def default_analyze(image_obj, redo=False, driver=None):
+def default_analyze(image_obj, options):
     """ Steps to analyze a container image (we assume it is a DockerImage
     object for now)
     1. Analyze the first layer to get a baseline list of packages
@@ -58,18 +58,18 @@ def default_analyze(image_obj, redo=False, driver=None):
     # set up empty master list of packages
     master_list = []
     # Analyze the first layer and get the shell
-    shell = single_layer.analyze_first_layer(image_obj, master_list, redo)
+    shell = single_layer.analyze_first_layer(image_obj, master_list, options)
     # Analyze the remaining layers if there are more
     if len(image_obj.layers) > 1:
         multi_layer.analyze_subsequent_layers(
-            image_obj, shell, master_list, redo, driver)
+            image_obj, shell, master_list, options)
     return image_obj
 
 
-def analyze(image_obj, redo=False, driver=None, extension=None):
+def analyze(image_obj, options):
     """Either analyze a container image using the default method or pass
     analysis to an external tool"""
-    if extension:
-        passthrough.run_extension(image_obj, extension, redo)
+    if options.extend:
+        passthrough.run_extension(image_obj, options.extend, options.redo)
     else:
-        default_analyze(image_obj, redo, driver)
+        default_analyze(image_obj, options)

--- a/tern/analyze/default/container/run.py
+++ b/tern/analyze/default/container/run.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 """
@@ -75,7 +75,8 @@ def execute_image(args):
     image_string = extract_image(args)
     # If the image has been extracted, load the metadata
     if image_string:
-        full_image = cimage.load_full_image(image_string, args.load_until_layer)
+        full_image = cimage.load_full_image(
+            image_string, args.load_until_layer)
         # check if the image was loaded successfully
         if full_image.origins.is_empty():
             # Add an image origin here
@@ -84,7 +85,7 @@ def execute_image(args):
             # Set up for analysis
             setup(full_image)
             # analyze image
-            cimage.analyze(full_image, args.redo, args.driver, args.extend)
+            cimage.analyze(full_image, args)
             # report out
             report.report_out(args, full_image)
             # clean up


### PR DESCRIPTION
To reduce code complexity, we introduce the concept of "options"
and "prerequisites". Options are passed as command line options.
Prerequisites are required arguments to a function. This is a
new class introduced in core.py and used to pass arguments to
execute_base and execute_snippets. The way we do it is create
the prereqs object in analyze_first_layer and
analyze_subsequent_layers. This reduces the complexity of passing
too many arguments to these functions.

Further, we follow this pattern in the dockerfile execution path.

Fixes #868

Signed-off-by: Nisha K <nishak@vmware.com>