### PR TITLE
Use GitPython for all git operations

### DIFF
--- a/tests/test_analyze_common.py
+++ b/tests/test_analyze_common.py
@@ -187,7 +187,7 @@ class TestAnalyzeCommon(unittest.TestCase):
         git_username_reg = r'([a-zA-Z\d_-]{0,38})'
         pattern = re.compile(r'github.com/'+git_username_reg+r'/tern')
         for url in url_list:
-            if pattern.match(url):
+            if pattern.search(url) is not None:
                 pass_num += 1
         self.assertEqual(pass_num, check_num)
 


### PR DESCRIPTION
Moving from using subprocesses to execute git commands to using
git module for the same. This eliminates # nosec dismissals for
some of the commands that shell out.

The tests are updated to accommodate the changes.

Resolves: #619

Signed-off-by: Dhairya Jain <jaindhairya2001@gmail.com>