### PR TITLE
Increase timeout for pulling large images

### DIFF
--- a/tern/load/docker_api.py
+++ b/tern/load/docker_api.py
@@ -28,7 +28,7 @@ def check_docker_setup():
     gracefully. The intent is that this function is run before any docker
     operations are invoked"""
     try:
-        client = docker.from_env(timeout=120)
+        client = docker.from_env(timeout=180)
         client.ping()
         return client
     except requests.exceptions.ConnectionError as e:


### PR DESCRIPTION
This is an addition to #631. Added 60 seconds, because of regular time-outs on bigger files.

Related to #630

Signed-off-by: Jeroen Knoops <jeroen.knoops@philips.com>