### PR TITLE
Compare ordered pkg_licenses for Package objects

### DIFF
--- a/tern/classes/package.py
+++ b/tern/classes/package.py
@@ -212,6 +212,11 @@ class Package:
         dictionaries.'''
         other_pkg_dict = other.to_dict()
         for key, value in self.to_dict().items():
+            if key == 'pkg_licenses':
+                # There may be more than one package license. Therefore,
+                # we must sort pkg_licenses before comparison
+                value.sort()
+                other_pkg_dict[key].sort()
             if value != other_pkg_dict[key]:
                 return False
         return True


### PR DESCRIPTION
When Tern compares two package objects to check if they are equal, it
iterates over the dictionary for each object and compares the values for
each key in both dictionaries. One of these keys is pkg_licenses whose
value is a list of package licenses. While most package managers only
return one package license per package, Debian-based container images
often will contain more than one as the package licenses are parsed from
their copyright text. If the pkg_licenses list is not sorted,
packages that are indeed equal will return false when the same list is
compared to itself in a different order. This issue was presenting
itself when Tern ran on a Debian-based dockerfile.

This commit resolves the issue with Debian-based dockerfiles by
sorting the pkg_licenses lists before comparing them in the
Package object is_equal method.

Resolves #899

Signed-off-by: Rose Judge <rjudge@vmware.com>