### PR TITLE
Use jq to detect npm components

### DIFF
--- a/tern/analyze/default/collect.py
+++ b/tern/analyze/default/collect.py
@@ -8,6 +8,7 @@ Functions to process data returned from invoking retrieval commands
 """
 
 import logging
+import os
 import subprocess  # nosec
 
 from tern.analyze.default.command_lib import command_lib
@@ -40,7 +41,10 @@ def get_snippet_list(invoke_step, work_dir=None, envs=None):
     if 'host' in invoke_step.keys():
         snippet_list = invoke_step.get('host')
         # If work_dir exist cd into it
-        if work_dir is not None:
+        if work_dir is None:
+            snippet_list.insert(
+                0, 'cd ' + os.path.join(rootfs.get_working_dir(), constants.mergedir))
+        else:
             snippet_list.insert(0, 'cd ' + work_dir)
         return 'host', snippet_list
     return '', []

--- a/tern/analyze/default/command_lib/base.yml
+++ b/tern/analyze/default/command_lib/base.yml
@@ -385,28 +385,37 @@ npm:
     invoke:
       1:
         container:
-          - "npm list -g | sed 's/\\(^[^a-z]*\\)\\([_.a-z0-9-]*\\)\\(@.*\\)/\\2/g' | grep -v '/usr*' | uniq"
+          - "npm list -g --json --long --depth=1000 > npm-global.json"
+      2:
+        host:
+          - "jq -r '.. | objects | select(has(\"name\") and has(\"version\")) | .name' npm-global.json"
     delimiter: "\n"
   versions:
     invoke:
       1:
         container:
-          - "pkgs=`npm list -g | sed 's/\\(^[^a-z]*\\)\\([_.a-z0-9-]*\\)\\(@.*\\)/\\2/g' | grep -v '/usr*' | uniq`"
-          - "for p in $pkgs; do npm show $p version; done"
+          - "npm list -g --json --long --depth=1000 > npm-global.json"
+      2:
+        host:
+          - "jq -r '.. | objects | select(has(\"name\") and has(\"version\")) | .version' npm-global.json"
     delimiter: "\n"
   licenses:
     invoke:
       1:
         container:
-          - "pkgs=`npm list -g | sed 's/\\(^[^a-z]*\\)\\([_.a-z0-9-]*\\)\\(@.*\\)/\\2/g' | grep -v '/usr*' | uniq`"
-          - "for p in $pkgs; do lic=`npm show $p license`; if [ -z \"$lic\" ]; then echo 'Unknown'; else echo $lic; fi; done"
+          - "npm list -g --json --long --depth=1000 > npm-global.json"
+      2:
+        host:
+          - "jq -r '.. | objects | select(has(\"name\") and has(\"version\")) | .license // \"Unknown\"' npm-global.json"
     delimiter: "\n"
   proj_urls:
     invoke:
       1:
         container:
-          - "pkgs=`npm list -g | sed 's/\\(^[^a-z]*\\)\\([_.a-z0-9-]*\\)\\(@.*\\)/\\2/g' | grep -v '/usr*' | uniq`"
-          - "for p in $pkgs; do npm view $p repository.url; done"
+          - "npm list -g --json --long --depth=1000 > npm-global.json"
+      2:
+        host:
+          - "jq -r '.. | objects | select(has(\"name\") and has(\"version\")) | .repository | if type == \"string\" then . else .url end | . // \"Unknown\"' npm-global.json"
     delimiter: "\n"
 # golang----------------------------------------------------------------------
 go:

--- a/tern/report/content.py
+++ b/tern/report/content.py
@@ -84,7 +84,7 @@ def print_invoke_list(info_dict, info):
                     report = report + '\t' + snippet + '\n'
             elif 'host' in info_dict[info]['invoke'][step]:
                 report = report + formats.invoke_on_host
-                for snippet in info_dict[info]['invoke'][step]['container']:
+                for snippet in info_dict[info]['invoke'][step]['host']:
                     report = report + '\t' + snippet + '\n'
     else:
         for value in info_dict[info]:


### PR DESCRIPTION
This removes the overhead of spinning up Node.js individually for each
package. Using jq reduces the runtime of npm detection from 20+ minutes
to under 1 second.

Closes #903

Signed-off-by: Jamie Magee <jamagee@microsoft.com>