### PR TITLE
Add GitPython as a runtime dependency

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,6 @@ jobs:
         run: |
           sudo apt-get install -y attr
           pip install --upgrade pip
-          pip install GitPython~=2.1
           pip install .
       - name: Prospector Linting
         run: |
@@ -30,7 +29,6 @@ jobs:
         run: |
           sudo apt-get install -y attr
           pip install --upgrade pip
-          pip install GitPython~=2.1
           pip install .
       - name: Commit Message Linting
         run: python ci/test_commit_message.py
@@ -45,7 +43,6 @@ jobs:
         run: |
           sudo apt-get install -y attr
           pip install --upgrade pip
-          pip install GitPython~=2.1
           pip install .
       - name: Security Linting
         run: |
@@ -62,7 +59,6 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y attr openjdk-8-jdk-headless maven
           pip install --upgrade pip
-          pip install GitPython~=2.1
           pip install .
           docker pull photon:3.0 && docker save photon:3.0 > photon.tar
           # build SPDX validation tool from source
@@ -82,7 +78,6 @@ jobs:
         run: |
           sudo apt-get install -y attr
           pip install --upgrade pip
-          pip install GitPython~=2.1
           pip install .
       - name: Test Coverage
         run: |

--- a/requirements.in
+++ b/requirements.in
@@ -14,3 +14,4 @@ pbr
 dockerfile-parse
 debut
 regex
+GitPython

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ stevedore>=3.3
 pbr>=5.5
 debut>=0.9
 regex>=2020.11
+GitPython~=3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,4 +56,4 @@ console_scripts =
     tern = tern.__main__:main
 
 [options.extras_require]
-dev = bandit>=1.6; prospector>=1.3; GitPython~=2.1; tox>=3.14
+dev = bandit>=1.6; prospector>=1.3; tox>=3.14

--- a/tox.ini
+++ b/tox.ini
@@ -8,10 +8,6 @@ envlist = py35
           changes
           coverage
 
-[testenv]
-description = Run tests
-deps = GitPython~=2.1
-
 [testenv:prospector]
 description = Run the Prospector test
 deps = prospector>=1.2


### PR DESCRIPTION
GitPython is currently a development dependency but when e01f826 was
merged it became a runtime dependency as well. This commit adds
GitPython to requirements.txt and removes it from tox.ini, setup.cfg
and pull_request.yml, which are all files where it was referenced
explicitly as a development dependency.

Resolves #917

Signed-off-by: Rose Judge <rjudge@vmware.com>