### PR TITLE
Refactor: Combine distroless into generic "host"

### DIFF
--- a/tern/analyze/default/command_lib/command_lib.py
+++ b/tern/analyze/default/command_lib/command_lib.py
@@ -7,7 +7,6 @@
 Invoking commands in the command library
 """
 
-import copy
 import logging
 import os
 import yaml
@@ -58,7 +57,7 @@ def get_base_listing(key):
     '''Given the key listing in base.yml, return the dictionary'''
     listing = {}
     if key in command_lib['base'].keys():
-        listing = copy.deepcopy(command_lib['base'][key])
+        listing = command_lib['base'][key]
     else:
         logger.warning("%s", errors.no_listing_for_base_key.format(
             listing_key=key))

--- a/tern/analyze/default/container/image.py
+++ b/tern/analyze/default/container/image.py
@@ -57,12 +57,12 @@ def default_analyze(image_obj, options):
                 kernel version 4.0 or later)"""
     # set up empty master list of packages
     master_list = []
-    # Analyze the first layer and get the shell
-    shell = single_layer.analyze_first_layer(image_obj, master_list, options)
+    # Analyze the first layer and get prerequisites for the next layer
+    prereqs = single_layer.analyze_first_layer(image_obj, master_list, options)
     # Analyze the remaining layers if there are more
-    if len(image_obj.layers) > 1:
+    if prereqs and len(image_obj.layers) > 1:
         multi_layer.analyze_subsequent_layers(
-            image_obj, shell, master_list, options)
+            image_obj, prereqs, master_list, options)
     return image_obj
 
 

--- a/tern/analyze/default/container/single_layer.py
+++ b/tern/analyze/default/container/single_layer.py
@@ -18,6 +18,7 @@ from tern.report import formats
 from tern.report import errors
 from tern.utils import constants
 from tern.utils import rootfs
+from tern.utils import host
 from tern.analyze import common as com
 from tern.analyze.default import default_common as dcom
 from tern.analyze.default import core
@@ -101,16 +102,16 @@ def mount_first_layer(layer_obj):
 
 
 def analyze_first_layer(image_obj, master_list, options):
-    """Analyze the first layer of an image. Return the installed shell.
-    If there is no installed shell, return None
-    1. Check if the layer is empty. If it is then we can't find a shell
+    """Analyze the first layer of an image. Return a Prereqs object for the
+    next layer.
+    1. Check if the layer is empty. If it is not, return None
     2. See if we can load the layer from cache
     3. If we can't load from cache
     3.1 See if we can find any information about the rootfs
     3.2 If we are able to find any information, use any prescribed methods
         to extract package information
     4. Process and bundle that information into the image object
-    5. Return the shell for subsequent layer processing"""
+    5. Return a Prereqs object for subsequent layer processing"""
     # set up a notice origin for the first layer
     origin_first_layer = 'Layer {}'.format(image_obj.layers[0].layer_index)
     # check if the layer is empty
@@ -122,34 +123,39 @@ def analyze_first_layer(image_obj, master_list, options):
     # create a Prereqs object
     prereqs = core.Prereqs()
     # find the shell from the first layer
-    prereqs.shell = dcom.get_shell(image_obj.layers[0])
-    if not prereqs.shell:
+    prereqs.fs_shell = dcom.get_shell(image_obj.layers[0])
+    # find a shell for the host
+    prereqs.host_shell = host.check_shell()
+    if not prereqs.fs_shell and not prereqs.host_shell:
         logger.warning(errors.no_shell)
         image_obj.layers[0].origins.add_notice_to_origins(
             origin_first_layer, Notice(errors.no_shell, 'warning'))
+    # set working directory for the snippets
+    prereqs.layer_workdir = image_obj.layers[0].get_layer_workdir()
     # find the binary from the first layer
     prereqs.binary = dcom.get_base_bin(image_obj.layers[0])
-    if not prereqs.binary:
-        logger.warning(errors.no_package_manager)
-        image_obj.layers[0].origins.add_notice_to_origins(
-            origin_first_layer, Notice(errors.no_package_manager, 'warning'))
+    # set a possible OS and package format
+    get_os_style(image_obj.layers[0], prereqs.binary)
     # try to load packages from cache
     if not com.load_from_cache(image_obj.layers[0], options.redo):
-        # set a possible OS
-        get_os_style(image_obj.layers[0], prereqs.binary)
         # if there is a binary, extract packages
-        if prereqs.shell and prereqs.binary:
+        if prereqs.binary:
             # mount the first layer
-            mount_first_layer(image_obj.layers[0])
+            target_dir = mount_first_layer(image_obj.layers[0])
+            # set the host path to the mount point
+            prereqs.host_path = target_dir
             # core default execution on the first layer
             core.execute_base(image_obj.layers[0], prereqs)
             # unmount
             rootfs.undo_mount()
             rootfs.unmount_rootfs()
-        # distroless images do not have a shell
-        elif prereqs.binary == 'distroless':
-            core.execute_distroless(image_obj.layers[0], prereqs)
+        else:
+            logger.warning(errors.no_package_manager)
+            image_obj.layers[0].origins.add_notice_to_origins(
+                origin_first_layer, Notice(
+                    errors.no_package_manager, 'warning'))
+            return None
     # populate the master list with all packages found in the first layer
     for p in image_obj.layers[0].packages:
         master_list.append(p)
-    return prereqs.shell
+    return prereqs


### PR DESCRIPTION
The "host" method should be available to all OSs that don't have
a shell and need a host script. This commit refactors the
"distroless" code such that the code execution remains OS agnostic.
Enabling new OSs should be done in the command_library and not
in the code.

- First we add some new properties to the Prereqs object that
  pertain to invoking a host script. That is a host path and a
  host shell.
- Next we refactor the core execution path to take just a Prereqs
  object rather than individual variables.
- Then we refactor the single_layer and multi_layer execution to
  set properties in the Prereqs object that is passed to it.
- We finally remove the duplicated code pertaining to "distroless"

This commit should also take care of the situation where there
is no commands or unrecognized commands in the image history. In
this case, there will be a fallback to executing the base script
entry.

Signed-off-by: Nisha K <nishak@vmware.com>