### PR TITLE
Add jq dependency to Dockerfiles and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ If you have a Linux OS you will need a distro with a kernel version >= 4.0 (Ubun
 - attr (sudo apt-get install attr or sudo dnf install attr)
 - Python 3.6 or newer (sudo apt-get install python3.6(3.7) or sudo dnf install python36(37))
 - Pip (sudo apt-get install python3-pip).
+- jq (sudo apt-get install jq or sudo dnf install jq)
 
-Some distro versions have all of these except `attr` preinstalled but `attr` is a common utility and is available via the package manager.
+Some distro versions have all of these except `attr` and/or `jq` preinstalled but both are common utilities and are available via the package manager.
 
 For Docker containers
 - Docker CE (Installation instructions can be found here: https://docs.docker.com/engine/installation/#server)

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && \
     findutils \
     git \
     gnupg2 \
+    jq \
     python3 \
     python3-pip \
     python3-setuptools \

--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -38,7 +38,7 @@ test_suite = {
     # requirements.txt
     re.compile('requirements.txt'): ['tern report -i photon:3.0'],
     # Dockerfile
-    re.compile('Dockerfile'): [
+    re.compile('docker/Dockerfile'): [
         'python3 setup.py sdist && '
         'docker build -t ternd -f ci/Dockerfile . && '
         './docker_run.sh ternd "report -i golang:alpine"'],
@@ -69,12 +69,13 @@ test_suite = {
      'tern report -f spdxtagvalue -i photon:3.0',
      'tern lock docker/Dockerfile'],
     # tern/command_lib
-    re.compile('tern/command_lib'): [
+    re.compile('tern/analyze/default/command_lib'): [
         'tern report -i photon:3.0',
         'tern report -i debian:buster',
         'tern report -i alpine:3.9',
         'tern report -i archlinux:latest',
-        'tern report -i centos:7'],
+        'tern report -i centos:7',
+        'tern report -i node:12.16-alpine'],
     # tern/analyze/default/dockerfile
     re.compile('tern/analyze/default/dockerfile'): [
         'python tests/test_analyze_default_dockerfile_parse.py',

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && \
     findutils \
     git \
     gnupg2 \
+    jq \
     python3 \
     python3-pip \
     python3-setuptools \

--- a/docker/Dockerfile.scancode
+++ b/docker/Dockerfile.scancode
@@ -10,6 +10,7 @@ RUN apt-get update && \
     findutils \
     git \
     gnupg2 \
+    jq \
     python3 \
     python3-pip \
     python3-setuptools \


### PR DESCRIPTION
Commit e0785a0 introduced new functionality that uses the host system's
jq package utility to detect and parse npm package metadata. This commit
adds jq as a dependency to the Tern Dockerfiles and also updates the CI
tests to add a npm-based docker image, node:12.16-alpine, as a test
image. Finally, this PR updates the README to include jq as a host
system dependency.

Signed-off-by: Rose Judge <rjudge@vmware.com>