### PR TITLE
bugfix: Escape empty braces when parsing snippets

### DIFF
--- a/tern/analyze/default/command_lib/command_lib.py
+++ b/tern/analyze/default/command_lib/command_lib.py
@@ -159,6 +159,10 @@ def set_command_attrs(command_obj):
 def collate_snippets(snippet_list, package=''):
     '''Given a list of snippets, make a concatenated string with all the
     commands'''
+    # Escape any braces that might confuse Python formatting
+    for i, snip in enumerate(snippet_list):
+        if '{}' in snip:
+            snippet_list[i] = snip.replace('{}', '{{}}')
     full_cmd = ''
     last_index = len(snippet_list) - 1
     for index in range(0, last_index):


### PR DESCRIPTION
An issue was found in Tern when empty curly braces were present in a
Dockerfile command (i.e. `ENV var=AUTH_{}`). Python was interpreting these
empty curly braces as a string to be formatted and thus, throwing a
ValueError. This commit fixes this bug by adding escape braces to the
string in the collate_snippets() function so that Python does not try to
interpret them as a string to be formatted.

Resolves #913

Signed-off-by: Rose Judge <rjudge@vmware.com>