### PR TITLE
Set WORKDIR directory to collect go modules

### DIFF
--- a/tern/analyze/default/container/multi_layer.py
+++ b/tern/analyze/default/container/multi_layer.py
@@ -89,6 +89,11 @@ def analyze_subsequent_layers(image_obj, prereqs, master_list, options):
     # get list of environment variables
     prereqs.envs = lock.get_env_vars(image_obj)
     while curr_layer < len(image_obj.layers):
+        # If work_dir changes, update value accordingly
+        # so we can later execute base.yml commands from the work_dir
+        if image_obj.layers[curr_layer].get_layer_workdir():
+            prereqs.layer_workdir = \
+                image_obj.layers[curr_layer].get_layer_workdir()
         # make a notice for each layer
         origin_next_layer = 'Layer {}'.format(
             image_obj.layers[curr_layer].layer_index)

--- a/tern/analyze/default/container/single_layer.py
+++ b/tern/analyze/default/container/single_layer.py
@@ -130,8 +130,6 @@ def analyze_first_layer(image_obj, master_list, options):
         logger.warning(errors.no_shell)
         image_obj.layers[0].origins.add_notice_to_origins(
             origin_first_layer, Notice(errors.no_shell, 'warning'))
-    # set working directory for the snippets
-    prereqs.layer_workdir = image_obj.layers[0].get_layer_workdir()
     # find the binary from the first layer
     prereqs.binary = dcom.get_base_bin(image_obj.layers[0])
     # set a possible OS and package format

--- a/tern/classes/image_layer.py
+++ b/tern/classes/image_layer.py
@@ -333,4 +333,4 @@ class ImageLayer:
         match = re.search(r"\bWORKDIR\ (\/\w+)+\b", self.created_by)
         if match:
             return match.group().split()[1]
-        return None
+        return ''


### PR DESCRIPTION
The WORKDIR command in a Dockerfile is used to define the working
directory of a container which means that any RUN, CMD, ADD, COPY or
ENTRYPOINT command that follows a WORKDIR command will be executed in
the working directory.

PR #768 added support to set the working directory which is required
especially for go module metadata collection. Part of this work was lost
in various refactors so this commit adds back the necessary code to set
the working directory properly. It also removes an attempt to set the
working directory in the base layer as the WORKDIR will always be set
after the first layer. As a result of this commit, Tern properly
collects go module information.

Resolves #924

Signed-off-by: Rose Judge <rjudge@vmware.com>