### PR TITLE
fix: Include information about layer's created_by

### DIFF
--- a/tern/analyze/default/container/multi_layer.py
+++ b/tern/analyze/default/container/multi_layer.py
@@ -14,6 +14,7 @@ from tern.utils import constants
 from tern.utils import rootfs
 from tern.classes.notice import Notice
 from tern.analyze import common
+from tern.report import formats
 from tern.analyze.default import default_common as dcom
 from tern.analyze.default import core
 from tern.analyze.default.dockerfile import lock
@@ -43,6 +44,12 @@ def fresh_analysis(image_obj, curr_layer, prereqs, options):
       what package managers were used.
     4 Use the prescribed methods for the package managers to retrieve
     """
+    # set up a notice origin for the current layer
+    origin_curr_layer = 'Layer {}'.format(
+        image_obj.layers[curr_layer].layer_index)
+    image_obj.layers[curr_layer].origins.add_notice_to_origins(
+        origin_curr_layer, Notice(formats.layer_created_by.format(
+            created_by=image_obj.layers[curr_layer].created_by), 'info'))
     # if there is no shell, try to see if it exists in the current layer
     if not prereqs.fs_shell:
         prereqs.shell = dcom.get_shell(image_obj.layers[curr_layer])

--- a/tern/analyze/default/container/single_layer.py
+++ b/tern/analyze/default/container/single_layer.py
@@ -114,6 +114,9 @@ def analyze_first_layer(image_obj, master_list, options):
     5. Return a Prereqs object for subsequent layer processing"""
     # set up a notice origin for the first layer
     origin_first_layer = 'Layer {}'.format(image_obj.layers[0].layer_index)
+    image_obj.layers[0].origins.add_notice_to_origins(
+        origin_first_layer, Notice(formats.layer_created_by.format(
+            created_by=image_obj.layers[0].created_by), 'info'))
     # check if the layer is empty
     if com.is_empty_layer(image_obj.layers[0]):
         logger.warning(errors.empty_layer)


### PR DESCRIPTION
When refactoring the default execution path into single_layer
and multi_layer, the info notice about the layer's created_by
was skipped. Granted, this information is probably repeated in
the layer object anyway, but this is the simplest way to add it
back to the reports because that information may or may not
be relevant to the consumers of the reports.

Signed-off-by: Nisha K <nishak@vmware.com>