### PR TITLE
Fix duplicate OS notices

### DIFF
--- a/tern/analyze/default/container/single_layer.py
+++ b/tern/analyze/default/container/single_layer.py
@@ -132,10 +132,10 @@ def analyze_first_layer(image_obj, master_list, options):
             origin_first_layer, Notice(errors.no_shell, 'warning'))
     # find the binary from the first layer
     prereqs.binary = dcom.get_base_bin(image_obj.layers[0])
-    # set a possible OS and package format
-    get_os_style(image_obj.layers[0], prereqs.binary)
     # try to load packages from cache
     if not com.load_from_cache(image_obj.layers[0], options.redo):
+        # set a possible OS and package format
+        get_os_style(image_obj.layers[0], prereqs.binary)
         # if there is a binary, extract packages
         if prereqs.binary:
             # mount the first layer


### PR DESCRIPTION
Previously, setting an OS was done before loading the cache,
causing multiple entries of the OS in the layer notices. Fixed this
by moving the setting of a possible OS only if the layer is not
loaded from the cache.

Signed-off-by: Nisha K <nishak@vmware.com>