### PR TITLE
Use deepcopy to find key listing dictionary

### DIFF
--- a/tern/analyze/default/command_lib/command_lib.py
+++ b/tern/analyze/default/command_lib/command_lib.py
@@ -10,6 +10,7 @@ Invoking commands in the command library
 import logging
 import os
 import yaml
+import copy
 import pkg_resources
 
 from tern.utils import constants
@@ -57,7 +58,7 @@ def get_base_listing(key):
     '''Given the key listing in base.yml, return the dictionary'''
     listing = {}
     if key in command_lib['base'].keys():
-        listing = command_lib['base'][key]
+        listing = copy.deepcopy(command_lib['base'][key])
     else:
         logger.warning("%s", errors.no_listing_for_base_key.format(
             listing_key=key))


### PR DESCRIPTION
This commit reverts a change in 98a12fc to use copy.deepcopy to assign
the key listing dictionary to prevent duplicate ENV variables in each
layers snippet_list.

Related: #921

Signed-off-by: Rose Judge <rjudge@vmware.com>