### PR TITLE
Use Debin Buster slim as Docker base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,38 +1,31 @@
 # Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-FROM debian:buster
+FROM python:3.9-slim-buster as base
 
-# Install fuse-overlayfs and Tern dependencies
-RUN apt-get update && \
-    apt-get -y install \
-    attr \
-    findutils \
-    git \
-    gnupg2 \
-    jq \
-    python3 \
-    python3-pip \
-    python3-setuptools \
-    tar \
-    util-linux \
-    wget && \
-    echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_10/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list && \
-    wget --no-verbose https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/Debian_10/Release.key -O - | apt-key add - && \
-    apt-get update && \
-    apt-get -y install \
-    buildah \
-    fuse-overlayfs && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+FROM base as builder
 
-# Adjust storage.conf to enable Fuse storage.
-RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' /etc/containers/storage.conf
+RUN mkdir /install
+WORKDIR /install
 
-# Install tern
-RUN pip3 install --upgrade pip && \
-    pip3 install --no-cache-dir \
+RUN pip install --no-warn-script-location --prefix=/install \
     tern
 
+FROM base
+
+RUN echo "deb http://deb.debian.org/debian bullseye main" > /etc/apt/sources.list.d/bullseye.list \
+    && echo "Package: *\nPin: release n=bullseye\nPin-Priority: 50" > /etc/apt/preferences.d/bullseye \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+    attr \
+    findutils \
+    fuse-overlayfs/bullseye \
+    fuse3/bullseye \
+    git \
+    jq \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /install /usr/local
+
 ENTRYPOINT ["tern", "--driver", "fuse"]
-CMD ["-h"]
+CMD ["--help"]

--- a/docker/Dockerfile.scancode
+++ b/docker/Dockerfile.scancode
@@ -1,39 +1,38 @@
 # Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-FROM debian:buster
+FROM python:3.9-slim-buster as base
 
-# Install fuse-overlayfs and Tern dependencies
-RUN apt-get update && \
-    apt-get -y install \
-    attr \
-    findutils \
-    git \
-    gnupg2 \
-    jq \
-    python3 \
-    python3-pip \
-    python3-setuptools \
-    tar \
-    util-linux \
-    wget && \
-    echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_10/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list && \
-    wget --no-verbose https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/Debian_10/Release.key -O - | apt-key add - && \
-    apt-get update && \
-    apt-get -y install \
-    buildah \
-    fuse-overlayfs && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+FROM base as builder
 
-# Adjust storage.conf to enable Fuse storage.
-RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' /etc/containers/storage.conf
+RUN mkdir /install
+WORKDIR /install
 
-# Install tern
-RUN pip3 install --upgrade pip && \
-    pip3 install --no-cache-dir \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-warn-script-location --prefix=/install \
     tern \
     scancode-toolkit[full]
 
+FROM base
+
+RUN echo "deb http://deb.debian.org/debian bullseye main" > /etc/apt/sources.list.d/bullseye.list \
+    && echo "Package: *\nPin: release n=bullseye\nPin-Priority: 50" > /etc/apt/preferences.d/bullseye \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+    attr \
+    findutils \
+    fuse-overlayfs/bullseye \
+    fuse3/bullseye \
+    git \
+    jq \
+    libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /install /usr/local
+
 ENTRYPOINT ["tern", "--driver", "fuse"]
-CMD ["-h"]
+CMD ["--help"]


### PR DESCRIPTION
Using Alpine Linux as the docker base image reduces the resultant image
from 681MB to 67MB

I've tested this with `docker run --privileged --rm --device /dev/fuse -v /var/run/docker.sock:/var/run/docker.sock tern report --docker-image ...`, but would appreciate input for more scenarios I haven't covered.

I would also appreciate input from @JeroenKnoops for the scancode variant of this image. Using this Alpine-based Dockerfile and adding `scancode-toolkit`, I was unable to build the image. It gets stuck resolving dependencies for scancode-toolkit. I can see that you've opened some issues in the scancode-toolkit repository, it appears that those haven't been completely resolved yet.