### PR TITLE
Use dpkg-query to list installed packages on debian

### DIFF
--- a/tern/analyze/default/command_lib/base.yml
+++ b/tern/analyze/default/command_lib/base.yml
@@ -79,28 +79,27 @@ dpkg:
       1:
         # Currently two types of environments are supported - host or container
         container:
-          - "dpkg --get-selections | cut -f1 -d':' | awk '{print $1}'"
+          - "dpkg-query -W -f '${Package}\n'"
     delimiter: "\n"
   # the length of this list should be the same as the names or else there will be a mismatch
   versions:
     invoke:
       1:
         container:
-          - "pkgs=`dpkg --get-selections | cut -f1 -d':' | awk '{print $1}'`"
-          - "for p in $pkgs; do dpkg -l $p | awk 'NR>5 {print $3}'; done"
+          - "dpkg-query -W -f '${Version}\n'"
     delimiter: "\n"
   copyrights:
     invoke:
       1:
         container:
-          - "pkgs=`dpkg --get-selections | cut -f1 -d':' | awk '{print $1}'`"
+          - "pkgs=`dpkg-query -W -f '${Package}\n'`"
           - "for p in $pkgs; do /bin/cat /usr/share/doc/$p/copyright; echo LICF; done"
     delimiter: 'LICF'
   files:
     invoke:
       1:
         container:
-        - "pkgs=`dpkg --get-selections | cut -f1 -d':' | awk '{print $1}'`"
+        - "pkgs=`dpkg-query -W -f '${Package}\n'`"
         - "for p in $pkgs; do files=`dpkg-query -L $p`; for file in $files; do if [ -f $file ]; then echo $file; fi; done; echo LICF; done"
     delimiter: "LICF"
   proj_urls: {}

--- a/tern/analyze/default/command_lib/base.yml
+++ b/tern/analyze/default/command_lib/base.yml
@@ -102,7 +102,12 @@ dpkg:
         - "pkgs=`dpkg-query -W -f '${Package}\n'`"
         - "for p in $pkgs; do files=`dpkg-query -L $p`; for file in $files; do if [ -f $file ]; then echo $file; fi; done; echo LICF; done"
     delimiter: "LICF"
-  proj_urls: {}
+  proj_urls:
+    invoke:
+      1:
+        container:
+          - "dpkg-query -W -f '${Homepage}\n' | /bin/sed 's/^$/Unknown/'"
+    delimiter: "\n"
 
 # apk ---------------------------------------------------------------------------------------------------------
 apk:


### PR DESCRIPTION
Use dpkg-query to list information about installed packages on debian
based images. dpkg-query has the option to format the ouput, which eliminates the need
to use cut + awk.

Also adds the proj_urls field to debian based images using dpkg-query. Sets url to 'Unknown' if blank.

Resolves #936

Signed-off-by: Yann Jorelle <yannjorelle@protonmail.com>