### PR TITLE
Generate SBoMs at container build time

### DIFF
--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -21,6 +21,7 @@ from tern import prep
 from tern.analyze.default.container import run as crun
 from tern.analyze.default.dockerfile import run as drun
 from tern.analyze.default.debug import run as derun
+from tern.analyze.default.live import run as lrun
 from tern.report import errors
 
 
@@ -48,6 +49,13 @@ logger.addHandler(log_handler)
 
 def check_file_existence(path):
     if not os.path.isfile(path):
+        msg = "{}: does not exist".format(path)
+        raise argparse.ArgumentTypeError(msg)
+    return path
+
+
+def check_dir_existence(path):
+    if not os.path.isdir(path):
         msg = "{}: does not exist".format(path)
         raise argparse.ArgumentTypeError(msg)
     return path
@@ -106,6 +114,8 @@ def do_main(args):
             check_image_input(args)
             # If the checks are OK, execute for docker image
             crun.execute_image(args)
+        elif args.live:
+            lrun.execute_live(args)
     elif args.sub == 'debug':
         derun.execute_debug(args)
     # Tear down the environment
@@ -192,9 +202,12 @@ def main():
                                help="Write the report to a file. "
                                "If no file is given the report will be "
                                "printed to the console.")
-    parser_report.add_argument('-l', '--live', action='store_true',
-                               help="Generate a report for the current state of the filesystem. "
-                               "This is useful when running Tern in a new namespace or VM.")
+    parser_report.add_argument('-l', '--live', default=None,
+                               type=check_dir_existence,
+                               metavar='PATH',
+                               help="Generate a report for the current state "
+                               "of the filesystem. This is useful when "
+                               "running Tern in a new namespace or VM.")
 
     # subparser for dockerfile lock
     parser_lock = subparsers.add_parser('lock',

--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -192,6 +192,9 @@ def main():
                                help="Write the report to a file. "
                                "If no file is given the report will be "
                                "printed to the console.")
+    parser_report.add_argument('-l', '--live', action='store_true',
+                               help="Generate a report for the current state of the filesystem. "
+                               "This is useful when running Tern in a new namespace or VM.")
 
     # subparser for dockerfile lock
     parser_lock = subparsers.add_parser('lock',

--- a/tern/analyze/default/collect.py
+++ b/tern/analyze/default/collect.py
@@ -134,7 +134,7 @@ def get_pkg_attrs(attr_dict, prereqs, package_name=''):
     return result, error_msgs
 
 
-def collect_list_metadata(listing, prereqs, mount=None):
+def collect_list_metadata(listing, prereqs, live=False):
     """Given the listing for the package manager, collect
     metadata that gets returned as a list
     The Prereqs object contains the state of the container filesystem and
@@ -146,7 +146,7 @@ def collect_list_metadata(listing, prereqs, mount=None):
     for item in command_lib.base_keys:
         # check if the supported items exist in the given listing
         if item in listing.keys():
-            if mount:
+            if live:
                 items, msg = lcol.get_attr_list(listing[item], prereqs)
             else:
                 items, msg = get_pkg_attrs(listing[item], prereqs)

--- a/tern/analyze/default/collect.py
+++ b/tern/analyze/default/collect.py
@@ -11,6 +11,7 @@ import logging
 import subprocess  # nosec
 
 from tern.analyze.default.command_lib import command_lib
+from tern.analyze.default.live import collect as lcol
 from tern.report import errors
 from tern.utils import constants
 from tern.utils import rootfs
@@ -133,7 +134,7 @@ def get_pkg_attrs(attr_dict, prereqs, package_name=''):
     return result, error_msgs
 
 
-def collect_list_metadata(listing, prereqs):
+def collect_list_metadata(listing, prereqs, mount=None):
     """Given the listing for the package manager, collect
     metadata that gets returned as a list
     The Prereqs object contains the state of the container filesystem and
@@ -145,7 +146,10 @@ def collect_list_metadata(listing, prereqs):
     for item in command_lib.base_keys:
         # check if the supported items exist in the given listing
         if item in listing.keys():
-            items, msg = get_pkg_attrs(listing[item], prereqs)
+            if mount:
+                items, msg = lcol.get_attr_list(listing[item], prereqs)
+            else:
+                items, msg = get_pkg_attrs(listing[item], prereqs)
             msgs = msgs + msg
             if item == 'files':
                 # convert this data into a list before adding it to the

--- a/tern/analyze/default/container/single_layer.py
+++ b/tern/analyze/default/container/single_layer.py
@@ -27,17 +27,14 @@ from tern.analyze.default import core
 logger = logging.getLogger(constants.logger_name)
 
 
-def get_os_release(base_layer):
-    '''Given the base layer object, determine if an os-release file exists and
-    return the PRETTY_NAME string from it. If no release file exists,
-    return an empty string. Assume that the layer filesystem is mounted'''
+def find_os_release(host_path):
+    """Find the OS PRETTY_NAME in the given path. If no os-release file
+    exists, return an empty string"""
     # os-release may exist under /etc/ or /usr/lib. We should first check
     # for the preferred /etc/os-release and fall back on /usr/lib/os-release
     # if it does not exist under /etc
-    etc_path = os.path.join(
-        rootfs.get_untar_dir(base_layer.tar_file), constants.etc_release_path)
-    lib_path = os.path.join(
-        rootfs.get_untar_dir(base_layer.tar_file), constants.lib_release_path)
+    etc_path = os.path.join(host_path, constants.etc_release_path)
+    lib_path = os.path.join(host_path, constants.lib_release_path)
     if not os.path.exists(etc_path):
         if not os.path.exists(lib_path):
             return ''
@@ -53,6 +50,12 @@ def get_os_release(base_layer):
             pretty_name = val
             break
     return pretty_name.strip('"')
+
+
+def get_os_release(base_layer):
+    """Assuming that the layer tarball is untarred are ready to be inspected,
+    get the OS information from the os-release file"""
+    return find_os_release(rootfs.get_untar_dir(base_layer.tar_file))
 
 
 def get_os_style(image_layer, binary):

--- a/tern/analyze/default/live/__init__.py
+++ b/tern/analyze/default/live/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause

--- a/tern/analyze/default/live/collect.py
+++ b/tern/analyze/default/live/collect.py
@@ -15,7 +15,6 @@ import re
 
 from tern.utils import rootfs
 from tern.utils import constants
-from tern.analyze.default import collect as dcol
 
 # global logger
 logger = logging.getLogger(constants.logger_name)
@@ -55,7 +54,7 @@ def snippets_to_script(snippet_list):
     final_list = []
     for snippet in snippet_list:
         # replace the escaped characters
-        for key in replace_dict.keys():
+        for key in replace_dict:
             snippet = re.sub(key, replace_dict[key], snippet)
         final_list.append(snippet)
     return " && ".join(final_list)
@@ -77,27 +76,3 @@ def invoke_live(snippet_list, prereqs, method):
     output, error = rootfs.shell_command(False, full_cmd)
     os.remove(script_path)
     return output, error
-
-
-def get_attr_list(attr_dict, prereqs):
-    """Similar to get_pkg_attrs in tern/analyze/default/collect.py but with
-    invocation on a live container image"""
-    error_msgs = ""
-    result = ""
-    if 'invoke' in attr_dict.keys():
-        for step in range(1, len(attr_dict['invoke'].keys()) + 1):
-            method, snippet_list = dcol.get_snippet_list(
-                attr_dict['invoke'][step], prereqs)
-            # invoke inventory script against the mount directory
-            result, error = invoke_live(snippet_list, prereqs, method)
-            if error:
-                logger.warning(
-                    "Error invoking command: %s", error.decode('utf-8'))
-                error_msgs = error_msgs + error.decode('utf-8')
-    if 'delimiter' in attr_dict.keys():
-        res_list = result.decode('utf-8').split(attr_dict['delimiter'])
-        if res_list[-1] == '' or res_list[-1] == '\n':
-            res_list.pop()
-            return res_list, error_msgs
-        return res_list, error_msgs
-    return result, error_msgs

--- a/tern/analyze/default/live/collect.py
+++ b/tern/analyze/default/live/collect.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Functions to collect package metadata from a live container filesystem.
+
+These functions are similar to the default collect.py functions except
+the invoking of the scripts occurs in a different environment.
+"""
+import os
+import re
+
+from tern.utils import rootfs
+from tern.utils import constants
+from tern.analyze.default import collect as dcol
+
+
+def create_script(command, shell, mount):
+    """Create the script to execute in an unshared environment"""
+    script = """#!/bin/sh
+
+mount -t proc /proc {mnt}/proc
+chroot {mnt} {shell} -c "{snip}"
+"""
+    script_path = os.path.join(rootfs.get_working_dir(), constants.script_file)
+    with open(script_path, 'w') as f:
+        f.write(script.format(mnt=mount, shell=shell, snip=command))
+    os.chmod(script_path, 0o700)
+    return script_path
+
+
+def snippets_to_script(snippet_list):
+    """Create a script out of the snippet list such that it can be invokable
+    via chroot's -c command"""
+    replace_dict = {r'\$': r'\\$',
+                    r'\`': r'\\`'}
+    final_list = []
+    for snippet in snippet_list:
+        # replace the escaped characters
+        for key in replace_dict.keys():
+            snippet = re.sub(key, replace_dict[key], snippet)
+        final_list.append(snippet)
+    return " && ".join(final_list)
+
+
+def invoke_live(snippet_list, shell, mount):
+    """Given a list of commands to run, the shell that is used to run the
+    commands, and the mount point, invoke the commands and return the result"""
+    # we first create a single command from the snippet list
+    command = snippets_to_script(snippet_list)
+    # we then insert this command into our unshare script
+    script_path = create_script(command, shell, mount)
+    full_cmd = ['unshare', '-mpf', '-r', script_path]
+    # invoke the script and remove it
+    output, error = rootfs.shell_command(False, full_cmd)
+    # os.remove(script_path)
+    return output, error
+
+
+def get_attr_list(attr_dict, shell, mount, work_dir=None, envs=None):
+    """Similar to get_pkg_attrs in tern/analyze/default/collect.py but with
+    invocation on a live container image"""
+    error_msgs = ""
+    result = ""
+    if 'invoke' in attr_dict.keys():
+        for step in range(1, len(attr_dict['invoke'].keys()) + 1):
+            method, snippet_list = dcol.get_snippet_list(
+                attr_dict['invoke'][step], work_dir, envs)
+            if method == 'container':
+                # invoke inventory script against the mount directory
+                result, error = invoke_live(snippet_list, shell, mount)
+                if error:
+                    error_msgs = error_msgs + error.decode('utf-8')
+    if 'delimiter' in attr_dict.keys():
+        res_list = result.decode('utf-8').split(attr_dict['delimiter'])
+        if res_list[-1] == '':
+            res_list.pop()
+            return res_list, error_msgs
+        return res_list, error_msgs
+    return result.decode('utf-8'), error_msgs

--- a/tern/analyze/default/live/run.py
+++ b/tern/analyze/default/live/run.py
@@ -21,6 +21,7 @@ from tern.analyze.default import default_common as dcom
 from tern.analyze.default import collect
 from tern.analyze.default import bundle
 from tern.analyze.default.command_lib import command_lib
+from tern.report import report
 
 # global logger
 logger = logging.getLogger(constants.logger_name)
@@ -69,5 +70,6 @@ def execute_live(args):
         # collect metadata into the layer object
         fill_packages(layer, mnt_path, shell)
         # report out the packages
+        report.report_layer(layer, args)
     else:
         logger.critical("No shell found. Cannot run default analysis")

--- a/tern/analyze/default/live/run.py
+++ b/tern/analyze/default/live/run.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Execution path for running tern at container image build time
+
+The idea is that using container building primitives, a mount point on the
+filesystem is already available and all that is left to do is to collect
+package information.
+"""
+import os
+
+from tern.classes.image_layer import ImageLayer
+from tern.analyze.default import common as com
+from tern.analyze.default import default_common as dcom
+from tern.analyze.default import collect
+from tern.analyze.default import bundle
+from tern.analyze.default.command_lib import command_lib
+
+
+def execute_live(args):
+    """Execute inventory at container build time
+    We assume a mounted working directory is ready to inventory"""
+    # create a layer object to bundle package metadata into
+    layer = ImageLayer("")
+    mnt_path = os.path.abspath(args.live)
+    # Find a shell that may exist in the layer
+    shell = dcom.find_shell(mnt_path)
+    # For every indicator that exists on the filesystem, inventory
+    # the packages
+    for bin in dcom.get_existing_bins(mnt_path):
+        listing = command_lib.get_base_listing(bin)
+        pkg_dict, invoke_msg, warnings = collect.collect_list_metadata(
+            shell, listing, args.live, work_dir=args.work_dir, envs=None)
+        # processing for debian copyrights
+        if listing.get("pkg_format") == "deb":
+            pkg_dict["pkg_licenses"] = com.get_deb_package_licenses(
+                pkg_dict["copyrights"])
+        bundle.fill_pkg_results(layer, pkg_dict)
+        com.remove_duplicate_layer_files(layer)

--- a/tern/analyze/default/live/run.py
+++ b/tern/analyze/default/live/run.py
@@ -10,33 +10,64 @@ The idea is that using container building primitives, a mount point on the
 filesystem is already available and all that is left to do is to collect
 package information.
 """
+import logging
 import os
 
+from tern.utils import constants
+from tern.utils import rootfs
 from tern.classes.image_layer import ImageLayer
-from tern.analyze.default import common as com
+from tern.analyze import common as com
 from tern.analyze.default import default_common as dcom
 from tern.analyze.default import collect
 from tern.analyze.default import bundle
 from tern.analyze.default.command_lib import command_lib
 
+# global logger
+logger = logging.getLogger(constants.logger_name)
+
+
+def setup():
+    """For the setup, we will just need to create the working directory"""
+    op_dir = rootfs.get_working_dir()
+    if not os.path.isdir(op_dir):
+        os.mkdir(op_dir)
+
+
+def fill_packages(layer, mount_path, shell):
+    """Collect package metadata and fill in the packages for the given layer
+    object"""
+    # For every indicator that exists on the filesystem, inventory the packages
+    for bin in dcom.get_existing_bins(mount_path):
+        listing = command_lib.get_base_listing(bin)
+        pkg_dict, invoke_msg, warnings = collect.collect_list_metadata(
+            shell, listing, work_dir=None, envs=None, mount=mount_path)
+        # processing for debian copyrights
+        if listing.get("pkg_format") == "deb":
+            pkg_dict["pkg_licenses"] = com.get_deb_package_licenses(
+                pkg_dict["copyrights"])
+        if invoke_msg:
+            logger.error("Script invocation error. Unable to collect some"
+                         "metadata.")
+        if warnings:
+            logger.warning("Some metadata may be missing.")
+        bundle.fill_pkg_results(layer, pkg_dict)
+        com.remove_duplicate_layer_files(layer)
+
 
 def execute_live(args):
     """Execute inventory at container build time
     We assume a mounted working directory is ready to inventory"""
+    logger.debug('Starting analysis...')
+    # create the working directory
+    setup()
     # create a layer object to bundle package metadata into
     layer = ImageLayer("")
     mnt_path = os.path.abspath(args.live)
     # Find a shell that may exist in the layer
     shell = dcom.find_shell(mnt_path)
-    # For every indicator that exists on the filesystem, inventory
-    # the packages
-    for bin in dcom.get_existing_bins(mnt_path):
-        listing = command_lib.get_base_listing(bin)
-        pkg_dict, invoke_msg, warnings = collect.collect_list_metadata(
-            shell, listing, args.live, work_dir=args.work_dir, envs=None)
-        # processing for debian copyrights
-        if listing.get("pkg_format") == "deb":
-            pkg_dict["pkg_licenses"] = com.get_deb_package_licenses(
-                pkg_dict["copyrights"])
-        bundle.fill_pkg_results(layer, pkg_dict)
-        com.remove_duplicate_layer_files(layer)
+    if shell:
+        # collect metadata into the layer object
+        fill_packages(layer, mnt_path, shell)
+        # report out the packages
+    else:
+        logger.critical("No shell found. Cannot run default analysis")

--- a/tern/analyze/default/live/run.py
+++ b/tern/analyze/default/live/run.py
@@ -15,9 +15,11 @@ import os
 
 from tern.utils import constants
 from tern.utils import rootfs
+from tern.utils import host
 from tern.classes.image_layer import ImageLayer
 from tern.analyze import common as com
 from tern.analyze.default import default_common as dcom
+from tern.analyze.default import core
 from tern.analyze.default import collect
 from tern.analyze.default import bundle
 from tern.analyze.default.command_lib import command_lib
@@ -34,14 +36,15 @@ def setup():
         os.mkdir(op_dir)
 
 
-def fill_packages(layer, mount_path, shell):
+def fill_packages(layer, prereqs):
     """Collect package metadata and fill in the packages for the given layer
     object"""
     # For every indicator that exists on the filesystem, inventory the packages
-    for bin in dcom.get_existing_bins(mount_path):
+    for bin in dcom.get_existing_bins(prereqs.host_path):
+        prereqs.binary = bin
         listing = command_lib.get_base_listing(bin)
         pkg_dict, invoke_msg, warnings = collect.collect_list_metadata(
-            shell, listing, work_dir=None, envs=None, mount=mount_path)
+            listing, prereqs, True)
         # processing for debian copyrights
         if listing.get("pkg_format") == "deb":
             pkg_dict["pkg_licenses"] = com.get_deb_package_licenses(
@@ -63,13 +66,14 @@ def execute_live(args):
     setup()
     # create a layer object to bundle package metadata into
     layer = ImageLayer("")
-    mnt_path = os.path.abspath(args.live)
+    # create a Prereqs object to store requirements to inventory
+    prereqs = core.Prereqs()
+    prereqs.host_path = os.path.abspath(args.live)
     # Find a shell that may exist in the layer
-    shell = dcom.find_shell(mnt_path)
-    if shell:
-        # collect metadata into the layer object
-        fill_packages(layer, mnt_path, shell)
-        # report out the packages
-        report.report_layer(layer, args)
-    else:
-        logger.critical("No shell found. Cannot run default analysis")
+    prereqs.fs_shell = dcom.find_shell(prereqs.host_path)
+    # Find the host's shell
+    prereqs.host_shell = host.check_shell()
+    # collect metadata into the layer object
+    fill_packages(layer, prereqs)
+    # report out the packages
+    report.report_layer(layer, args)

--- a/tern/formats/default/generator.py
+++ b/tern/formats/default/generator.py
@@ -42,7 +42,8 @@ def print_full_report(image, print_inclusive):
            print_inclusive is False:
             continue
         if layer.import_image:
-            notes = notes + print_full_report(layer.import_image, print_inclusive)
+            notes = notes + print_full_report(
+                layer.import_image, print_inclusive)
         else:
             notes = notes + get_layer_notices(layer)
             (layer_pkg_list, layer_license_list,
@@ -55,6 +56,19 @@ def print_full_report(image, print_inclusive):
             notes += formats.layer_licenses_list.format(list=", ".join(
                 layer_license_list) if layer_license_list else 'None')
             notes = notes + formats.package_demarkation
+    return notes
+
+
+def print_layer_report(layer):
+    """Generate a report for a given layer"""
+    notes = get_layer_notices(layer)
+    pkgs, licenses, filelicenses = get_layer_info_list(layer)
+    notes += formats.layer_file_licenses_list.format(
+        list=filelicenses)
+    notes += formats.layer_packages_list.format(
+        list=", ".join(pkgs) if pkgs else 'None')
+    notes += formats.layer_licenses_list.format(list=", ".join(
+        licenses) if licenses else 'None')
     return notes
 
 
@@ -138,3 +152,10 @@ class Default(generator.Generate):
         if report_only:
             return report
         return report + print_licenses_only(image_obj_list)
+
+    def generate_layer(self, layer):
+        """Generate a default report for one layer object"""
+        report = formats.disclaimer.format(
+            version_info=content.get_tool_version())
+        logger.debug("Generating summary report for layer...")
+        return report + print_layer_report(layer)

--- a/tern/formats/html/generator.py
+++ b/tern/formats/html/generator.py
@@ -103,6 +103,28 @@ The following report was generated for "%s" image.
 """
 
 
+head_layer = """
+<!DOCTYPE html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="https://fonts.googleapis.com/css2?family=Inconsolata:wght@300&family=Oswald&display=swap"
+rel="stylesheet"><link href="https://fonts.googleapis.com/css2?family=Josefin+Sans:ital,wght@1,300&display=swap"
+rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inconsolata&display=swap" rel="stylesheet">
+%s \n
+</head>
+<body>
+<div class="header">
+<img src="https://raw.githubusercontent.com/tern-tools/tern/master/docs/img/tern_logo.png" height="60px">\n
+<br>
+</div>\n
+<div style="font-family: \'Inconsolata\', monospace;">
+<p>
+Tern at %s
+</div>
+"""
+
+
 def image_handler(list_obj, indent):
     '''Write html code for the images list in the report with
     image name as title'''
@@ -297,4 +319,14 @@ class HTML(generator.Generate):
         for the images'''
         report_dict = get_report_dict(image_obj_list)
         report = create_html_report(report_dict, image_obj_list)
+        return report
+
+    def generate_layer(self, layer):
+        """Given a layer object, create a html report for the layer"""
+        logger.debug("Creating HTML report...")
+        report = ""
+        report = report + '\n' + head_layer % (css, get_tool_version())
+        report = report + '\n' + report_dict_to_html(layer.to_dict())
+        report = report + '\n' + js
+        report = report + '\n' + '</body>\n</html>\n'
         return report

--- a/tern/formats/json/generator.py
+++ b/tern/formats/json/generator.py
@@ -19,3 +19,7 @@ class JSON(generator.Generate):
             image_list.append({'image': image.to_dict()})
         image_dict = {'images': image_list}
         return json.dumps(image_dict)
+
+    def generate_layer(self, layer):
+        """Create a json object for one layer"""
+        return json.dumps(layer.to_dict())

--- a/tern/formats/spdx/spdxjson/file_helpers.py
+++ b/tern/formats/spdx/spdxjson/file_helpers.py
@@ -91,3 +91,17 @@ def get_files_list(image_obj, template):
                         filedata, template, layer_checksum))
                     file_refs.add(file_ref)
     return file_dicts
+
+
+def get_layer_files_list(layer_obj, template, timestamp):
+    """Given a layer object and the SPDX template mapping, return a list
+    of SPDX dictionary representations for each file in the layer"""
+    file_dicts = []
+    file_refs = set()
+    for filedata in layer_obj.files:
+        # we do not know the layer's id so we will use the timestamp instead
+        file_ref = spdx_common.get_file_spdxref(filedata, timestamp)
+        if file_ref not in file_refs:
+            file_dicts.append(get_file_dict(filedata, template, timestamp))
+            file_refs.add(file_ref)
+    return file_dicts

--- a/tern/formats/spdx/spdxjson/formats.py
+++ b/tern/formats/spdx/spdxjson/formats.py
@@ -21,6 +21,10 @@ license_list_version = '3.8'
 creator = 'Tool: tern-{version}'
 created = '{timestamp}'
 
+document_name_snapshot = 'Tern SPDX JSON SBoM'
+document_namespace_snapshot = 'https://spdx.org/spdxdocs/tern-report-' \
+    '{timestamp}-{uuid}'
+
 
 # Dictionary Formatting
 def get_relationship_dict(element_id, related_element_id, relationship_type):

--- a/tern/formats/spdx/spdxjson/generator.py
+++ b/tern/formats/spdx/spdxjson/generator.py
@@ -104,8 +104,7 @@ def get_document_dict_snapshot(layer_obj, template):
         'name': json_formats.document_name_snapshot,
         'dataLicense': json_formats.data_license,
         'comment': json_formats.document_comment,
-        'documentNamespace': get_document_namespace_snapshot(
-            layer_obj, timestamp),
+        'documentNamespace': get_document_namespace_snapshot(timestamp),
         # we will list all the unique package SPDXRefs here later
         'documentDescribes': [],
         # these will contain just the packages as there is no layer

--- a/tern/formats/spdx/spdxjson/package_helpers.py
+++ b/tern/formats/spdx/spdxjson/package_helpers.py
@@ -66,3 +66,19 @@ def get_packages_list(image_obj, template):
                 package_dicts.append(get_package_dict(package, template))
                 package_refs.add(pkg_ref)
     return package_dicts
+
+
+def get_layer_packages_list(layer, template):
+    """Given a layer object and a SPDX template object, return a list
+    of SPDX dictionary representations for each of the packages in the layer
+    and their package references"""
+    package_dicts = []
+    package_refs = set()
+    for package in layer.packages:
+        # Create a list of dictionaries. Each dictionary represents
+        # one package object in the image
+        pkg_ref = spdx_common.get_package_spdxref(package)
+        if pkg_ref not in package_refs:
+            package_dicts.append(get_package_dict(package, template))
+            package_refs.add(pkg_ref)
+    return package_dicts, list(package_refs)

--- a/tern/formats/spdx/spdxtagvalue/generator.py
+++ b/tern/formats/spdx/spdxtagvalue/generator.py
@@ -141,3 +141,8 @@ class SpdxTagValue(generator.Generate):
         report += mhelpers.get_image_block(image_obj, template) + '\n'
 
         return report
+
+    def generate_layer(self, layer_obj):
+        """Currently Unsupported. Provide debug statement"""
+        logger.critical("Generating SPDX tag-value documents at container "
+                        "build time is currently unsupported")

--- a/tern/formats/spdx/spdxtagvalue/generator.py
+++ b/tern/formats/spdx/spdxtagvalue/generator.py
@@ -142,7 +142,7 @@ class SpdxTagValue(generator.Generate):
 
         return report
 
-    def generate_layer(self, layer_obj):
+    def generate_layer(self, layer_obj):  # pylint: disable=unused-argument
         """Currently Unsupported. Provide debug statement"""
         logger.critical("Generating SPDX tag-value documents at container "
                         "build time is currently unsupported")

--- a/tern/formats/yaml/generator.py
+++ b/tern/formats/yaml/generator.py
@@ -28,3 +28,7 @@ class YAML(generator.Generate):
         for image in image_obj_list:
             report = report + print_yaml_report(image)
         return report
+
+    def generate_layer(self, layer):
+        """Generate a yaml report for the given layer object"""
+        return yaml.dump(layer.to_dict(), default_flow_style=False)

--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -47,7 +47,8 @@ def clean_working_dir():
 def generate_report(args, *images):
     '''Generate a report based on the command line options'''
     if args.report_format:
-        return generate_format(images, args.report_format, args.print_inclusive)
+        return generate_format(
+            images, args.report_format, args.print_inclusive)
     return generate_format(images, 'default', args.print_inclusive)
 
 
@@ -66,14 +67,30 @@ def generate_format(images, format_string, print_inclusive):
         pass
 
 
+def generate_format_layer(layer, format_string):
+    """Generate a report in the format of format_string given one layer
+    object. This is similar to the generate_format function"""
+    try:
+        mgr = driver.DriverManager(
+            namespace='tern.formats',
+            name=format_string,
+            invoke_on_load=True,
+        )
+        return mgr.driver.generate_layer(layer)
+    except NoMatches:
+        pass
+
+
 def report_out(args, *images):
     for img in images:
-        if args.load_until_layer > img.total_layers and args.load_until_layer != 0:
+        if (args.load_until_layer > img.total_layers and
+                args.load_until_layer != 0):
             # The actual ignoring is done in docker_image.py
             # Warning is given here for visibility to user
             logger.warning(f'Given layer {args.load_until_layer} exceeds total'
-                           + f' number of layers in image ({img.total_layers}).'
-                           + ' Ignoring --layer option and generating report for'
+                           + f' number of layers in image ({img.total_layers})'
+                           + '. Ignoring --layer option and generating report '
+                           + 'for'
                            + f' {img.total_layers} total layers')
     report = generate_report(args, *images)
     if not report:
@@ -82,3 +99,20 @@ def report_out(args, *images):
         write_report(report, args)
     else:
         print(report)
+
+
+def report_layer(layer, args):
+    """Generate a report for one layer object"""
+    layer_report = ""
+    if args.report_format:
+        layer_report = generate_format_layer(layer, args.report_format)
+    else:
+        layer_report = generate_format_layer(layer, 'default')
+    if not layer_report:
+        logger.error(
+            "Unable to generate %s report type for layer", args.report_format)
+    else:
+        if args.output_file:
+            write_report(layer_report, args)
+        else:
+            print(layer_report)

--- a/tern/utils/constants.py
+++ b/tern/utils/constants.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 '''
@@ -49,3 +49,5 @@ mergedir = 'mergedir'
 locked_dockerfile = 'Dockerfile.lock'
 # temporary directory for multistage Dockerfile analysis
 multistage_dir = 'dftemp'
+# temporary file name for unshared script
+script_file = 'invoke.sh'


### PR DESCRIPTION
Fixes #849 #850 #853 #859

This merge enables Tern to inventory and generate an SBoM against
a mounted container filesystem. This feature is meant to work
along with other container build tools. For example, one can
use buildah[1] to spin up a working container, mount it, and
perform some actions on it. One of those actions can be the
inventory of packages at that state of the container, thus
generating an SBoM for each layer tarball of the container.

For example, we can do this:

ctr=$(buildah from scratch)
mnt=$(buildah mount $ctr)
buildah add $ctr debian-bullseye.tar
buildah commit $ctr debian:bullseye-tern <-- create container layer
tern -q report --live $mnt -o sbom <-- inventory and generate sbom
buildah unmount $ctr

In order to use the feature, the full path to the mounted filesystem
at container build time should be provided to tern:
tern report --live path/to/mount/point

Currently, none of the extensions have been fully tested. However,
the default inventory method is the one that is best suited for
inventorying at container build time. All formats except the
SPDX tag-value format are supported. As of this commit, the
SPDX JSON format is more suitable for the container build use case
and existing tools can ingest this format in an easier fashion.

Signed-off-by: Nisha K <nishak@vmware.com>
