### PR TITLE
Add support to recognize ADD/COPY by created_by parser

### DIFF
--- a/tern/analyze/default/filter.py
+++ b/tern/analyze/default/filter.py
@@ -14,7 +14,10 @@ import re
 from tern.analyze.default.command_lib import command_lib
 from tern.analyze import common
 from tern.report import formats
+from tern.report import errors
 from tern.utils import constants
+
+CMDS_NEEDS_ANALYSIS = ['ADD', 'COPY']
 
 # global logger
 logger = logging.getLogger(constants.logger_name)
@@ -105,7 +108,13 @@ def filter_install_commands(shell_command_line):
     if ignore_msgs:
         report = report + formats.ignored + ignore_msgs
     if unrec_msgs:
-        report = report + formats.unrecognized + unrec_msgs
+        cmd_check = list(filter(
+            lambda word: word in CMDS_NEEDS_ANALYSIS, unrec_msgs.split(' ')))
+        if cmd_check:
+            msg = errors.no_able_to_analyze.format(entity='file')
+            report += msg + unrec_msgs
+        else:
+            report += formats.unrecognized + unrec_msgs
     if branch_report:
         report = report + branch_report
     return consolidate_commands(filter2), report

--- a/tern/report/errors.py
+++ b/tern/report/errors.py
@@ -81,6 +81,7 @@ cannot_find_image = '''Cannot find image {imagetag} locally or from remote '''\
     '''registry.\n'''
 empty_layer = '''Empty layer. Nothing to do.\n'''
 no_layer_created_by = "No created_by information for layer."
+no_able_to_analyze = "unknown {entity}. please analyze separately "
 
 # not error messages but stuff for the logger
 no_base_image = '''Base image is FROM scratch. Skipping to build'''


### PR DESCRIPTION
Add support to recognize ADD/COPY by
created_by parser

This change adds support to notify not
able to analyze few commands such as ADD/COPY
by tern.

Work towards: #929

Signed-off-by: Mukul Taneja <mtaneja@vmware.com>