### PR TITLE
fix: Set layer creation notice only on cache miss

### DIFF
--- a/tern/analyze/default/container/single_layer.py
+++ b/tern/analyze/default/container/single_layer.py
@@ -114,9 +114,6 @@ def analyze_first_layer(image_obj, master_list, options):
     5. Return a Prereqs object for subsequent layer processing"""
     # set up a notice origin for the first layer
     origin_first_layer = 'Layer {}'.format(image_obj.layers[0].layer_index)
-    image_obj.layers[0].origins.add_notice_to_origins(
-        origin_first_layer, Notice(formats.layer_created_by.format(
-            created_by=image_obj.layers[0].created_by), 'info'))
     # check if the layer is empty
     if com.is_empty_layer(image_obj.layers[0]):
         logger.warning(errors.empty_layer)
@@ -137,6 +134,10 @@ def analyze_first_layer(image_obj, master_list, options):
     prereqs.binary = dcom.get_base_bin(image_obj.layers[0])
     # try to load packages from cache
     if not com.load_from_cache(image_obj.layers[0], options.redo):
+        # add a notice if there is a "created by"
+        image_obj.layers[0].origins.add_notice_to_origins(
+            origin_first_layer, Notice(formats.layer_created_by.format(
+                created_by=image_obj.layers[0].created_by), 'info'))
         # set a possible OS and package format
         get_os_style(image_obj.layers[0], prereqs.binary)
         # if there is a binary, extract packages


### PR DESCRIPTION
Moved adding a Notice object to the Layer origins only when
we fail to load that layer from the cache. This prevents multiple
Notice objects for the layer creation info being created and stored
in the cache and producing multiple lines in the reports.

Fixes #942

Signed-off-by: Nisha K <nishak@vmware.com>