### PR TITLE
Reorganize package metadata info in default report

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -15,3 +15,4 @@ dockerfile-parse
 debut
 regex
 GitPython
+prettytable

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ pbr>=5.5
 debut>=0.9
 regex>=2021.3
 GitPython~=3.1
+prettytable~=2.1

--- a/tern/formats/default/generator.py
+++ b/tern/formats/default/generator.py
@@ -13,6 +13,7 @@ from tern.report import formats
 from tern.formats import generator
 from tern.report import content
 from tern.utils import constants
+from prettytable import PrettyTable
 
 
 # global logger
@@ -45,30 +46,23 @@ def print_full_report(image, print_inclusive):
             notes = notes + print_full_report(
                 layer.import_image, print_inclusive)
         else:
-            notes = notes + get_layer_notices(layer)
-            (layer_pkg_list, layer_license_list,
-             file_level_licenses) = get_layer_info_list(layer)
-            # Collect files + packages + licenses in the layer
-            notes += formats.layer_file_licenses_list.format(
-                list=file_level_licenses)
-            notes += formats.layer_packages_list.format(
-                list=", ".join(layer_pkg_list) if layer_pkg_list else 'None')
-            notes += formats.layer_licenses_list.format(list=", ".join(
-                layer_license_list) if layer_license_list else 'None')
-            notes = notes + formats.package_demarkation
+            notes += print_layer_report(layer)
+            notes += formats.package_demarkation
     return notes
 
 
 def print_layer_report(layer):
     """Generate a report for a given layer"""
     notes = get_layer_notices(layer)
-    pkgs, licenses, filelicenses = get_layer_info_list(layer)
+    filelicenses, pkgs_table = get_layer_info_list(layer)
     notes += formats.layer_file_licenses_list.format(
         list=filelicenses)
-    notes += formats.layer_packages_list.format(
-        list=", ".join(pkgs) if pkgs else 'None')
-    notes += formats.layer_licenses_list.format(list=", ".join(
-        licenses) if licenses else 'None')
+    if pkgs_table:
+        notes += formats.layer_packages_header.format('\n')
+        for line in pkgs_table.splitlines():
+            notes += '\t' + line + '\n'
+    else:
+        notes += formats.layer_packages_header.format("None\n")
     return notes
 
 
@@ -103,11 +97,13 @@ def get_extension_headers(layers):
 
 def get_layer_info_list(layer):
     '''Given a layer, collect files + packages + licenses in the layer,
-    return them as lists.'''
-    layer_pkg_list = []
-    layer_license_list = []
+    return them as a PrettyTable string object.'''
     layer_file_licenses_list = []
     file_level_licenses = None
+    package_list = PrettyTable()
+    package_list.field_names = ["Package", "Version", "License"]
+    package_list.align = "l"
+    package_list.print_empty = False
 
     for f in layer.files:
         layer_file_licenses_list.extend(f.license_expressions)
@@ -117,16 +113,10 @@ def get_layer_info_list(layer):
         file_level_licenses = ", ".join(layer_file_licenses_list)
 
     for package in layer.packages:
-        pkg = package.name + "-" + package.version
-        if pkg not in layer_pkg_list and pkg:
-            layer_pkg_list.append(pkg)
+        package_list.add_row([package.name, package.version,
+                              package.pkg_license])
 
-        package_licenses = content.get_package_licenses(package)
-        for package_license in package_licenses:
-            if package_license not in layer_license_list:
-                layer_license_list.append(package_license)
-
-    return layer_pkg_list, layer_license_list, file_level_licenses
+    return file_level_licenses, package_list.get_string()
 
 
 def print_licenses_only(image_obj_list):

--- a/tern/report/formats.py
+++ b/tern/report/formats.py
@@ -44,7 +44,7 @@ package_version = '''Version: {package_version}\n'''
 package_url = '''Project URL: {package_url}\n'''
 package_license = '''License: {package_license}\n'''
 package_copyright = '''Copyright Text: {package_copyright}\n'''
-layer_packages_list = '''\tPackages found in Layer:  {list}\n'''
+layer_packages_header = '''\tPackages found in Layer: {}'''
 layer_licenses_list = '''\tLicenses found in Layer:  {list}\n'''
 layer_file_licenses_list = '''\tFile licenses found in Layer:  {list}\n'''
 full_licenses_list = '''###########################################\n'''\
@@ -55,8 +55,8 @@ full_licenses_list = '''###########################################\n'''\
 package_notes = '''Errors: {package_info_retrieval_errors}\n''' \
     '''Improvements: {package_info_reporting_improvements}\n'''
 # demarkation
-package_demarkation = '''------------------------------------------------''' \
-    '''\n\n'''
+package_demarkation = '''================================================='''\
+    '''======================================\n\n'''
 
 # informational
 loading_from_cache = '''Loading packages from cache for layer {layer_id}'''


### PR DESCRIPTION
Currently in the default report, Tern displays package name, version and
license metadata as unique lists, i.e.

```
	Packages found in Layer: pk1-ver1, pkg2-ver2, pkg3-ver3, etc
	Licenses found in Layer: lic1, lic2, lic3, etc
```

In an attempt to better organize this information, and to display which
package is associated with which license, we can use the prettytable
python library to organize package metadata in a table by layer, i.e.

```
        +---------------+-------------+---------+
        | Package       | Version     | License |
        +---------------+-------------+---------+
        | pkg1          | ver1        | lic2    |
        | pkg2          | ver2        | lic1    |
        +---------------+-------------+---------+

```

This commit uses prettytable to put all layer packages into a table and
also eliminates duplicate code in formats/default/generator.py by using
`get_layer_info_list()` in the `print_full_report()` function.

Works towards #930

Signed-off-by: Rose Judge <rjudge@vmware.com>