### PR TITLE
Deprecate command library commands in reports

### DIFF
--- a/tern/analyze/default/core.py
+++ b/tern/analyze/default/core.py
@@ -56,9 +56,8 @@ def execute_base(layer_obj, prereqs):
     # find the binary listing
     listing = command_lib.get_base_listing(prereqs.binary)
     if listing:
-        # put info notice about what is going to be invoked
-        snippet_msg = (formats.invoke_for_base + '\n' +
-                       content.print_base_invoke(prereqs.binary))
+        # put generic notice about how package metadata is collected
+        snippet_msg = formats.invoke_for_base.format(binary=prereqs.binary)
         layer_obj.origins.add_notice_to_origins(
             origin_layer, Notice(snippet_msg, 'info'))
         # get list of metadata by invoking scripts in chroot
@@ -78,8 +77,6 @@ def execute_base(layer_obj, prereqs):
                 origin_layer, Notice(invoke_msg, 'error'))
         if warnings:
             logger.warning("Some metadata may be missing")
-            layer_obj.origins.add_notice_to_origins(
-                origin_layer, Notice(warnings, 'warning'))
         # bundle the results into Package objects
         bundle.fill_pkg_results(layer_obj, pkg_dict)
         # remove extra FileData objects from the layer

--- a/tern/report/content.py
+++ b/tern/report/content.py
@@ -93,18 +93,6 @@ def print_invoke_list(info_dict, info):
     return report
 
 
-def print_base_invoke(key):
-    '''Given the key in the base library, return a string containing
-    the command_lib/base.yml'''
-    info = command_lib.get_base_listing(key)
-    report = ''
-    for item in command_lib.base_keys:
-        if item in info.keys():
-            report = report + print_invoke_list(info, item)
-    report = report + '\n'
-    return report
-
-
 def print_package_invoke(command_name):
     '''Given the command name to look up in the snippet library and the
     package name, return a string with the list of commands that will be

--- a/tern/report/formats.py
+++ b/tern/report/formats.py
@@ -33,7 +33,8 @@ retrieve_from_cache = '''Retrieving packages from cache for layer ''' \
 # command library
 base_listing = '''Direct listing in command_lib/base.yml'''
 snippet_listing = '''Direct listing in command_lib/snippets.yml'''
-invoke_for_base = '''Retrieved by invoking listing in command_lib/base.yml'''
+invoke_for_base = '''Retrieved package metadata using {binary} ''' \
+    '''default method. \n'''
 invoke_for_snippets = '''Retrieved by invoking listing in command_lib/''' \
     '''snippets.yml'''
 invoke_in_container = '''\tin container:\n'''


### PR DESCRIPTION
The reports are becoming too verbose when printing out in detail the
commands that were used to fetch the metadata information. The logging
already has this information. In order to simplify the reports, this
commit removes adding notices about collection information to the layer
origin object and, as a result, deprecates the `print_base_invoke()`
function.

Resolves #823

Signed-off-by: Rose Judge <rjudge@vmware.com>