### PR TITLE
CI: Test lock with single stage Dockerfile

### DIFF
--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -67,7 +67,7 @@ test_suite = {
     re.compile('tern/classes/template.py'):
     ['python tests/test_class_template.py',
      'tern report -f spdxtagvalue -i photon:3.0',
-     'tern lock docker/Dockerfile'],
+     'tern lock samples/single_stage_tern/Dockerfile'],
     # tern/command_lib
     re.compile('tern/analyze/default/command_lib'): [
         'tern report -i photon:3.0',
@@ -83,7 +83,7 @@ test_suite = {
         'tern report -i golang:alpine',
         'tern report -d samples/alpine_python/Dockerfile',
         'tern report -w photon.tar',
-        'tern lock docker/Dockerfile'],
+        'tern lock samples/single_stage_tern/Dockerfile'],
     # tern/load
     re.compile('tern/load'): [
         'python tests/test_load_docker_api.py'],

--- a/samples/single_stage_tern/Dockerfile
+++ b/samples/single_stage_tern/Dockerfile
@@ -1,0 +1,38 @@
+# Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+FROM debian:buster
+
+# Install fuse-overlayfs and Tern dependencies
+RUN apt-get update && \
+    apt-get -y install \
+    attr \
+    findutils \
+    git \
+    gnupg2 \
+    jq \
+    python3 \
+    python3-pip \
+    python3-setuptools \
+    tar \
+    util-linux \
+    wget && \
+    echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_10/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list && \
+    wget --no-verbose https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/Debian_10/Release.key -O - | apt-key add - && \
+    apt-get update && \
+    apt-get -y install \
+    buildah \
+    fuse-overlayfs && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Adjust storage.conf to enable Fuse storage.
+RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' /etc/containers/storage.conf
+
+# Install tern
+RUN pip3 install --upgrade pip && \
+    pip3 install --no-cache-dir \
+    tern
+
+ENTRYPOINT ["tern", "--driver", "fuse"]
+CMD ["-h"]


### PR DESCRIPTION
At this time "lock" does not work well with multistage Dockerfiles
especially when using the "as" clause to alias build stages. As
a result of switching to multistage Dockerfiles for building
Tern's own container images, the test that uses these Dockerfiles
fail. We replace the test Dockerfile with an old copy of Tern's
Dockerfile.

- Add Tern's old Dockerfile to samples
- Change tests to use this Dockerfile

Signed-off-by: Nisha K <nishak@vmware.com>