### PR TITLE
Fixed an issue with the export command on some images

### DIFF
--- a/tern/analyze/default/collect.py
+++ b/tern/analyze/default/collect.py
@@ -33,7 +33,7 @@ def get_snippet_list(invoke_step, prereqs):
         if prereqs.envs:
             for var in prereqs.envs:
                 snippet_list.insert(
-                    0, 'export ' + var.split('=')[0] + '=' + var.split('=')[1])
+                    0, 'export ' + var.split('=')[0] + '=\"' + var.split('=')[1] + '\"')
         # If work_dir exist cd into it
         if prereqs.layer_workdir:
             snippet_list.insert(0, 'cd ' + prereqs.layer_workdir)


### PR DESCRIPTION
Running:
`tern report -i nexus3.onap.org:10001/onap/vid -f json -o vid.json` 
resulted in an error: 
`export: Bad variable name` 
because tern tried to run the export command with spaces inside the variable value.
Adding quotation marks fixed the bug.