### PR TITLE
Better parsing of created_by values

### DIFF
--- a/tern/analyze/default/default_common.py
+++ b/tern/analyze/default/default_common.py
@@ -121,16 +121,22 @@ def get_commands_from_metadata(image_layer):
     origin_layer = 'Layer {}'.format(image_layer.layer_index)
     # check if there is a key containing the script that created the layer
     if image_layer.created_by:
-        command_line = fltr.get_run_command(image_layer.created_by)
-        if command_line:
+        cmd, instr = fltr.get_run_command(image_layer.created_by)
+        if image_layer.layer_index != 1 and instr in ['ADD', 'COPY']:
+            # add a notice saying we cannot analyze files
+            # imported from the host during container build
+            image_layer.origins.add_notice_to_origins(
+                origin_layer, Notice(errors.no_able_to_analyze, 'warning'))
+            return []
+        if cmd:
             command_list, msg = fltr.filter_install_commands(
-                general.clean_command(command_line))
+                general.clean_command(cmd))
             if msg:
                 image_layer.origins.add_notice_to_origins(
                     origin_layer, Notice(msg, 'warning'))
             return command_list
     image_layer.origins.add_notice_to_origins(
-        origin_layer, Notice(errors.no_layer_created_by, 'warning'))
+        origin_layer, Notice(errors.no_created_by, 'warning'))
     return []
 
 

--- a/tern/analyze/default/dockerfile/lock.py
+++ b/tern/analyze/default/dockerfile/lock.py
@@ -218,24 +218,24 @@ def lock_dockerfile(dfobj, image_obj):
     the content to pin packages to their versions"""
     # get all the RUN commands in the dockerfile
     run_list = parse.get_run_layers(dfobj)
-    # go through the image layers to find the corresponding to the Dockerfile
-    # RUN lines
+    # go through the image layers to find the ones corresponding to the
+    # run commands
     for layer in image_obj.layers:
         if not layer.import_str:
             # this layer is not from a FROM line
             # we get the layer instruction
-            command = fltr.get_run_command(layer.created_by)
-            # check which run command has this instruction
-            for run_dict in run_list:
-                if run_dict['value'] == command:
-                    # this is the run instruction that created this layer
-                    # get the list of install commands
-                    command_list, _ = fltr.filter_install_commands(
-                        general.clean_command(run_dict['value']))
-                    # pin packages installed by each command
-                    run_index = dfobj.structure.index(run_dict)
-                    dfobj = lock_layer_instruction(
-                        dfobj, run_index, command_list, layer)
+            cmd, instr = fltr.get_run_command(layer.created_by)
+            if instr == 'RUN':
+                # find the line in the Dockerfile that matches this command
+                for run_dict in run_list:
+                    if run_dict['value'] == cmd:
+                        # get the list of install commands
+                        command_list, _ = fltr.filter_install_commands(
+                            general.clean_command(run_dict['value']))
+                        # pin packages installed by each command
+                        run_index = dfobj.structure.index(run_dict)
+                        dfobj = lock_layer_instruction(
+                            dfobj, run_index, command_list, layer)
     return dfobj
 
 

--- a/tern/analyze/default/dockerfile/parse.py
+++ b/tern/analyze/default/dockerfile/parse.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2020 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 """
@@ -23,7 +23,6 @@ logger = logging.getLogger(constants.logger_name)
 directives = ['FROM',
               'ARG',
               'ADD',
-              'RUN',
               'ENV',
               'COPY',
               'ENTRYPOINT',

--- a/tern/report/errors.py
+++ b/tern/report/errors.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2020 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 """
@@ -80,8 +80,8 @@ no_running_docker_container = '''Cannot invoke commands in a container '''\
 cannot_find_image = '''Cannot find image {imagetag} locally or from remote '''\
     '''registry.\n'''
 empty_layer = '''Empty layer. Nothing to do.\n'''
-no_layer_created_by = "No created_by information for layer."
-no_able_to_analyze = "Unknown {entity}. Please analyze separately."
+no_created_by = '''No information about filesystem creation'''
+no_able_to_analyze = "Unknown content. Additional analysis may be required."
 
 # not error messages but stuff for the logger
 no_base_image = '''Base image is FROM scratch. Skipping to build'''

--- a/tern/report/formats.py
+++ b/tern/report/formats.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2020 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 """
@@ -83,7 +83,6 @@ dockerfile_line = '''Instruction Line: {dockerfile_instruction}'''
 image_build_failure = '''Failed to build image from Dockerfile'''
 image_load_failure = '''Failed to load metadata for built image {testimage}'''
 layer_created_by = '''Layer created by commands: {created_by}'''
-no_created_by = '''No information about filesystem creation'''
 
 # docker image report
 docker_image = '''Docker image: {imagetag}'''


### PR DESCRIPTION
When using Docker or Buildkit to build container images,
the config will contain a `created_by` key which contains the
shell command that was run to create the container image layer.
Typically, this command is followed by a comment #(nop) indicating
the commented out part of the shell command. This applies to
Docker directives other than RUN. We want to be able to not only
extract the RUN command but also if directives like ADD and COPY
were used to indicate that the added content is unknown in the
reports.

- Modified the get_run_command function to return the command and
  the instruction directive used from the created_by line.
- Modified the get_commands_from_metadata function to use the tuple
  returned by the get_run_command function to check for ADD and
  COPY instructions.
- Moved error message for no created by information from
  report/formats.py to report/errors.py as it is an error message.
- Modified the lock_dockerfile function to use the tuple returned
  by the get_run_command function to match the RUN commands in the
  image to the RUN instructions in the Dockerfile.

Fixes #918

Signed-off-by: Nisha K <nishak@vmware.com>