### PR TITLE
Update debug execution path with prereqs object

### DIFF
--- a/tern/analyze/default/debug/run.py
+++ b/tern/analyze/default/debug/run.py
@@ -19,6 +19,7 @@ from tern.utils import rootfs
 from tern.utils import constants
 from tern.analyze.default.command_lib import command_lib
 from tern.analyze.default import collect
+from tern.analyze.default import core
 from tern.analyze.default.container import run
 from tern.analyze.default.container import image as cimage
 from tern.analyze.default.container import single_layer
@@ -60,6 +61,9 @@ def look_up_lib(keys):
 def invoke_script(args):
     """Assuming we have a mounted filesystem, invoke the script in the
     command library"""
+    # make a Prereqs object
+    prereqs = core.Prereqs()
+    prereqs.shell = args.shell
     # if we're looking up the snippets library
     # we should see 'snippets' in the keys
     if 'snippets' in args.keys and 'packages' in args.keys:
@@ -72,7 +76,7 @@ def invoke_script(args):
     else:
         info_dict = look_up_lib(args.keys)
     result = collect.get_pkg_attrs(
-        info_dict, args.shell, package_name=args.package)
+        info_dict, prereqs, package_name=args.package)
     print()
     print("*************************************************************")
     print("          Command Library Script Verification mode           ")


### PR DESCRIPTION
Commit 733eb12 refactored Tern to pass command line arguments as a
single object, prereqs, instead of the arg.* values separately. The
debug execution path was not updated to use the prereqs object, however,
and therefore, was throwing an AttributeError trying to read
'args.shell' as a prereqs object. This commit updates the debug
execution path to utilize a prereqs object.

Resolves #967

Signed-off-by: Rose Judge <rjudge@vmware.com>