### PR TITLE
Record and report scancode file licenses

### DIFF
--- a/tern/extensions/scancode/executor.py
+++ b/tern/extensions/scancode/executor.py
@@ -160,7 +160,10 @@ def add_file_data(layer_obj, collected_files):
         checkfile = collected_files.pop()
         for f in layer_obj.files:
             if f.merge(checkfile):
+                # file already exists and has now been updated
                 break
+        # file didn't previously exist in layer so add it now
+        layer_obj.files.append(checkfile)
 
 
 def add_package_data(layer_obj, collected_packages):

--- a/tern/formats/default/generator.py
+++ b/tern/formats/default/generator.py
@@ -106,7 +106,7 @@ def get_layer_info_list(layer):
     package_list.print_empty = False
 
     for f in layer.files:
-        layer_file_licenses_list.extend(f.license_expressions)
+        layer_file_licenses_list.extend(f.licenses)
 
     layer_file_licenses_list = list(set(layer_file_licenses_list))
     if layer_file_licenses_list:

--- a/tern/report/content.py
+++ b/tern/report/content.py
@@ -26,9 +26,9 @@ def get_layer_files_licenses(layer):
     '''Given a image layer collect complete list of file licenses'''
     file_level_licenses = set()
     for f in layer.files:
-        for license_expression in f.license_expressions:
-            if license_expression:
-                file_level_licenses.add(license_expression)
+        for lic in f.licenses:
+            if lic:
+                file_level_licenses.add(lic)
     return list(file_level_licenses)
 
 


### PR DESCRIPTION
Running Tern with the scancode extension was not reporting file level
license information due to a logic error. This commit updates the
add_file_data() function in scancode/executor.py to update file metadata
from scancode if the file already exists in the cache, or if not, add
the file object to the layer file list.

This commit also changes the default format to report the name of the
file licenses instead of the license expression as the license is human
readable and consistent with the other human readable license
expressions typically reported by the package managers.

Resolves #959

Signed-off-by: Rose Judge <rjudge@vmware.com>