### PR TITLE
Install scancode in /install

### DIFF
--- a/docker/Dockerfile.scancode
+++ b/docker/Dockerfile.scancode
@@ -17,7 +17,8 @@ RUN pip install --no-warn-script-location --prefix=/install \
     tern
 
 COPY docker/requirements.scancode.txt /install/requirements.scancode.txt
-RUN pip install -r /install/requirements.scancode.txt
+RUN pip install --prefix=/install \
+    -r /install/requirements.scancode.txt
 
 FROM base
 


### PR DESCRIPTION
Sorry for introducing this error.

I forgot to install scancode in the `/install` directory

Closes: #979