### PR TITLE
Fix prereqs.fs_shell variable naming

### DIFF
--- a/tern/analyze/default/container/multi_layer.py
+++ b/tern/analyze/default/container/multi_layer.py
@@ -52,7 +52,7 @@ def fresh_analysis(image_obj, curr_layer, prereqs, options):
             created_by=image_obj.layers[curr_layer].created_by), 'info'))
     # if there is no shell, try to see if it exists in the current layer
     if not prereqs.fs_shell:
-        prereqs.shell = dcom.get_shell(image_obj.layers[curr_layer])
+        prereqs.fs_shell = dcom.get_shell(image_obj.layers[curr_layer])
     # mount diff layers from 0 till the current layer
     target = mount_overlay_fs(image_obj, curr_layer, options.driver)
     # set this layer's host path

--- a/tern/analyze/default/core.py
+++ b/tern/analyze/default/core.py
@@ -106,7 +106,7 @@ def execute_snippets(layer_obj, command_obj, prereqs):
         pkg_invoke = command_lib.check_for_unique_package(
             prereqs.listing, pkg_name)
         deps, deps_msg = com.get_package_dependencies(
-            pkg_invoke, pkg_name, prereqs.shell)
+            pkg_invoke, pkg_name, prereqs.fs_shell)
         if deps_msg:
             logger.warning(deps_msg)
             layer_obj.origins.add_notice_to_origins(
@@ -117,6 +117,6 @@ def execute_snippets(layer_obj, command_obj, prereqs):
     # get package metadata for each package name
     for pkg_name in unique_pkgs:
         pkg = Package(pkg_name)
-        dcom.fill_package_metadata(pkg, pkg_invoke, prereqs.shell,
+        dcom.fill_package_metadata(pkg, pkg_invoke, prereqs.fs_shell,
                                    layer_obj.get_layer_workdir(), prereqs.envs)
         layer_obj.add_package(pkg)

--- a/tern/analyze/default/debug/run.py
+++ b/tern/analyze/default/debug/run.py
@@ -63,7 +63,7 @@ def invoke_script(args):
     command library"""
     # make a Prereqs object
     prereqs = core.Prereqs()
-    prereqs.shell = args.shell
+    prereqs.fs_shell = args.shell
     # if we're looking up the snippets library
     # we should see 'snippets' in the keys
     if 'snippets' in args.keys and 'packages' in args.keys:


### PR DESCRIPTION
A Prereqs object has an attribute named 'fs_shell' that represents the
container filesystem shell. This variable was incorrectly referred to as
just 'shell' in a handful of files which meant the shell value was
lost and in some cases causing errors. This commit corrects the fs_shell
variable references.

Resolves #975

Signed-off-by: Rose Judge <rjudge@vmware.com>