### PR TITLE
Show package type in default report

### DIFF
--- a/tern/analyze/default/bundle.py
+++ b/tern/analyze/default/bundle.py
@@ -67,7 +67,7 @@ def convert_to_pkg_dicts(attr_lists):
     return pkg_list
 
 
-def fill_pkg_results(image_layer, pkg_list_dict):
+def fill_pkg_results(image_layer, pkg_list_dict, pkg_format):
     """Fill results from collecting package information into the image layer
     object"""
     if 'names' in pkg_list_dict and len(pkg_list_dict['names']) > 1:
@@ -75,4 +75,5 @@ def fill_pkg_results(image_layer, pkg_list_dict):
         for pkg_dict in pkg_list:
             pkg = Package(pkg_dict['name'])
             pkg.fill(pkg_dict)
+            pkg.pkg_format = pkg_format
             image_layer.add_package(pkg)

--- a/tern/analyze/default/core.py
+++ b/tern/analyze/default/core.py
@@ -78,7 +78,7 @@ def execute_base(layer_obj, prereqs):
         if warnings:
             logger.warning("Some metadata may be missing")
         # bundle the results into Package objects
-        bundle.fill_pkg_results(layer_obj, pkg_dict)
+        bundle.fill_pkg_results(layer_obj, pkg_dict, listing.get("pkg_format"))
         # remove extra FileData objects from the layer
         com.remove_duplicate_layer_files(layer_obj)
     # if there is no listing add a notice

--- a/tern/analyze/default/live/run.py
+++ b/tern/analyze/default/live/run.py
@@ -84,7 +84,7 @@ def fill_packages(layer, prereqs):
                          "metadata.")
         if warnings:
             logger.warning("Some metadata may be missing.")
-        bundle.fill_pkg_results(layer, pkg_dict)
+        bundle.fill_pkg_results(layer, pkg_dict, listing.get("pkg_format"))
         com.remove_duplicate_layer_files(layer)
 
 

--- a/tern/classes/package.py
+++ b/tern/classes/package.py
@@ -42,6 +42,7 @@ class Package:
         self.__origins = Origins()
         self.__files = []
         self.__pkg_licenses = []
+        self.__pkg_format = ''
 
     @property
     def name(self):
@@ -114,6 +115,14 @@ class Package:
     @checksum.setter
     def checksum(self, checksum):
         self.__checksum = checksum
+
+    @property
+    def pkg_format(self):
+        return self.__pkg_format
+
+    @pkg_format.setter
+    def pkg_format(self, pkg_format):
+        self.__pkg_format = pkg_format
 
     def get_file_paths(self):
         """Return a list of paths of all the files in a package"""

--- a/tern/formats/default/generator.py
+++ b/tern/formats/default/generator.py
@@ -101,7 +101,7 @@ def get_layer_info_list(layer):
     layer_file_licenses_list = []
     file_level_licenses = None
     package_list = PrettyTable()
-    package_list.field_names = ["Package", "Version", "License"]
+    package_list.field_names = ["Package", "Version", "License", "Pkg Format"]
     package_list.align = "l"
     package_list.print_empty = False
 
@@ -114,7 +114,7 @@ def get_layer_info_list(layer):
 
     for package in layer.packages:
         package_list.add_row([package.name, package.version,
-                              package.pkg_license])
+                              package.pkg_license, package.pkg_format])
 
     return file_level_licenses, package_list.get_string()
 

--- a/tests/test_class_package.py
+++ b/tests/test_class_package.py
@@ -160,7 +160,8 @@ class TestClassPackage(unittest.TestCase):
                   'checksum': 'abcxyz',
                   'pkg_licenses': ['MIT', 'GPL'],
                   'files': [{'name': 'a.txt', 'path': '/usr/a.txt'},
-                            {'name': 'b.txt', 'path': '/lib/b.txt'}]}
+                            {'name': 'b.txt', 'path': '/lib/b.txt'}],
+                  'pkg_format': 'rpm'}
         p = Package('p1')
         p.fill(p_dict)
         self.assertEqual(p.name, 'p1')


### PR DESCRIPTION
This commit adds package type/format information to the default report.
This is a useful datapoint as it corresponds to the package manager in
base.yml that was used to inventory the layer. Sometimes there may be
two collection  methods used per layer and it will be helpful to
differentiate between the two by noting the package format.

**NOTE: This PR does not include some tests for the new `Package` attribute
`pkg_format` for a reason -- I am going to open an issue to add these
tests as a `good first issue` for Grace Hopper Open Source Day.**

Resolves #984

Signed-off-by: Rose Judge <rjudge@vmware.com>