### PR TITLE
Fix live execution if no previous sboms are given

### DIFF
--- a/tern/analyze/default/live/run.py
+++ b/tern/analyze/default/live/run.py
@@ -155,7 +155,9 @@ def execute_live(args):
         # resolve the packages for each of the layers
         context_layers.append(layer)
         resolve_context_packages(context_layers)
+        final_layer = context_layers.pop()
+    else:
+        final_layer = layer
     # report out the packages
-    final_layer = context_layers.pop()
     logger.debug("Preparing report")
     report.report_layer(final_layer, args)


### PR DESCRIPTION
context_layers was used without being assigned anything in the
case when only one layer was present. To fix this, we assign the
variable final_layer to the one layer we had created and only
popped the final layer in the case when previous sboms were given.

Signed-off-by: Nisha K <nishak@vmware.com>