### PR TITLE
Initial CycloneDX JSON support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Tern is a software package inspection tool that can create a Software Bill of Ma
   - [YAML Format](#report-yaml)
   - [SPDX tag-value Format](#report-spdxtagvalue)
   - [SPDX JSON Format](#report-spdxjson)
+  - [CycloneDX JSON Format](#report-cyclonedxjson)
 - [Extensions](#extensions)
   - [Scancode](#scancode)
   - [cve-bin-tool](#cve-bin-tool)
@@ -255,6 +256,14 @@ $ tern report -f spdxtagvalue -i golang:1.12-alpine -o spdx.txt
 The SPDX JSON format contains the same information that an SPDX Tag-value document does. The only difference between these two formats is the way the information is represented. The 'spdxjson' format represents the container information as a collection of key-value pairs. In some cases, the SPDX JSON format may be more interoperable between cloud native compliance tools.
 ```
 $ tern report -f spdxjson -i golang:1.12-alpine -o spdx.json
+```
+
+## CycloneDX JSON Format<a name="report-cyclonedxjson">
+[OWASP CycloneDX](https://cyclonedx.org/) is a lightweight software bill of materials standard designed for use in application security contexts and supply chain component analysis. The National Telecommunications and Information Administration (NTIA) [recognizes CycloneDX](https://www.ntia.gov/files/ntia/publications/sbom_options_and_decision_points_20210427-1.pdf) as one of three valid SBoM formats that satisfies the minimum viable requirements for an SBoM in accordance with President Biden's [Executive Order on Improving the Nation's Cybersecurity](https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/).
+
+Many tools for producing and consuming CycloneDX SBoMs are listed in the [CycloneDX Tool Center](https://cyclonedx.org/tool-center/).
+```
+$ tern report -f cyclonedxjson -i golang:1.12-alpine -o bom.json
 ```
 
 # Extensions<a name="extensions">

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ debian-inspector>=21.5
 regex>=2021.7
 GitPython~=3.1
 prettytable~=2.1
+packageurl-python>=0.9.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ tern.formats =
     jsonc = tern.formats.json.consumer:JSON
     yaml = tern.formats.yaml.generator:YAML
     html = tern.formats.html.generator:HTML
+    cyclonedxjson = tern.formats.cyclonedx.cyclonedxjson.generator:CycloneDXJSON
 tern.extensions =
     cve_bin_tool = tern.extensions.cve_bin_tool.executor:CveBinTool
     scancode = tern.extensions.scancode.executor:Scancode

--- a/tern/analyze/default/command_lib/base.yml
+++ b/tern/analyze/default/command_lib/base.yml
@@ -434,7 +434,7 @@ npm:
     delimiter: "LICF"
 # golang----------------------------------------------------------------------
 go:
-  pkg_format: 'go.mod'
+  pkg_format: 'go'
   os_guess:
     - 'None'
   path:

--- a/tern/formats/cyclonedx/__init__.py
+++ b/tern/formats/cyclonedx/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021 Patrick Dwyer. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause

--- a/tern/formats/cyclonedx/cyclonedx_common.py
+++ b/tern/formats/cyclonedx/cyclonedx_common.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021 Patrick Dwyer. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Common functions that are useful for CycloneDX document creation
+"""
+
+import datetime
+import uuid
+from tern.utils import general
+
+
+###################
+# General Helpers #
+###################
+
+
+# document level tool information
+metadata_tool = {
+    'vendor': 'Tern Tools',
+    'name': 'Tern',
+    'version': general.get_git_rev_or_version()[1]
+}
+
+
+# keys are what Tern uses, values what CycloneDX uses
+hash_type_mapping = {
+    'md5': 'MD5',
+    'sha1': 'SHA-1',
+    'sha256': 'SHA-256',
+}
+
+
+purl_types_with_namespaces = [
+    'deb',
+    'rpm',
+    'apk',
+]
+
+
+def get_serial_number():
+    ''' Return a randomly generated CycloneDX BOM serial number '''
+    return 'urn:uuid:' + str(uuid.uuid4())
+
+
+def get_timestamp():
+    ''' Return a timestamp suitable for the BOM timestamp '''
+    return datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+
+
+def get_hash(checksum_type, checksum):
+    ''' Return a CycloneDX hash object from Tern checksum values '''
+    hash_algorithm = hash_type_mapping.get(checksum_type, None)
+    return None if hash_algorithm is None else {'alg': hash_algorithm, 'content': checksum}
+
+
+def get_property(name, value):
+    ''' Return a CycloneDX property object '''
+    return {'name': name, 'value': value}
+
+
+def get_purl_namespace(os_guess, pkg_format):
+    if pkg_format in purl_types_with_namespaces:
+        return os_guess.partition(' ')[0].lower()
+    return None
+
+
+def get_os_guess(image_obj):
+    return image_obj.layers[0].os_guess or None
+
+
+def get_license_from_name(name):
+    return {'license': {'name': name}}

--- a/tern/formats/cyclonedx/cyclonedxjson/__init__.py
+++ b/tern/formats/cyclonedx/cyclonedxjson/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021 Patrick Dwyer. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause

--- a/tern/formats/cyclonedx/cyclonedxjson/generator.py
+++ b/tern/formats/cyclonedx/cyclonedxjson/generator.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021 Patrick Dwyer. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+'''
+CycloneDX JSON document generator
+'''
+
+import json
+import logging
+
+from tern.utils import constants
+from tern.formats import generator
+from tern.formats.cyclonedx import cyclonedx_common
+from tern.formats.cyclonedx.cyclonedxjson import image_helpers as mhelpers
+from tern.formats.cyclonedx.cyclonedxjson import package_helpers as phelpers
+
+
+# global logger
+logger = logging.getLogger(constants.logger_name)
+
+
+def get_document_dict(image_obj_list):
+    ''' Return document info as a dictionary '''
+    docu_dict = {
+        'bomFormat': 'CycloneDX',
+        'specVersion': '1.3',
+        'serialNumber': cyclonedx_common.get_serial_number(),
+        'version': 1,
+        'metadata': {
+            'timestamp': cyclonedx_common.get_timestamp(),
+            'tools': [cyclonedx_common.metadata_tool],
+        },
+        'components': [],
+    }
+
+    # if representing a single image populate top level BOM metadata component
+    # else representing multiple images so list them as components
+    if len(image_obj_list) == 1:
+        docu_dict['metadata']['component'] = mhelpers.get_image_dict(image_obj_list[0])
+        docu_dict['components'] = phelpers.get_packages_list(image_obj_list[0])
+    else:
+        for image_obj in image_obj_list:
+            image_componet = mhelpers.get_image_dict(image_obj)
+            image_componet['components'] = phelpers.get_packages_list(image_obj)
+            docu_dict['components'].append(image_componet)
+
+    return docu_dict
+
+
+class CycloneDXJSON(generator.Generate):
+    def generate(self, image_obj_list, print_inclusive=False):
+        ''' Generate a CycloneDX document
+        The whole document should be stored in a dictionary which can be
+        converted to JSON and dumped to a file using the write_report function
+        in report.py. '''
+        logger.debug('Generating CycloneDX JSON document...')
+
+        report = get_document_dict(image_obj_list)
+
+        return json.dumps(report, indent=2)

--- a/tern/formats/cyclonedx/cyclonedxjson/image_helpers.py
+++ b/tern/formats/cyclonedx/cyclonedxjson/image_helpers.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021 Patrick Dwyer. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+'''
+Helper functions for image level JSON CycloneDX document dictionaries
+'''
+
+
+from tern.formats.cyclonedx import cyclonedx_common
+from packageurl import PackageURL
+
+
+def get_image_dict(image_obj):
+    ''' Given an image object return the CycloneDX document dictionary for the
+    given image. For CycloneDX, the image is a component and hence follows the
+    JSON spec for components. '''
+    image_dict = {
+        'type': 'container',
+        'scope': 'required',
+        'name': image_obj.name,
+        'version': image_obj.checksum_type + ':' + image_obj.checksum,
+        'hashes': [],
+        'properties': []
+    }
+
+    purl = PackageURL('docker', None, image_dict['name'], image_dict['version'])
+    image_dict['purl'] = str(purl)
+
+    if image_obj.repotags:
+        for repotag in image_obj.repotags:
+            image_dict['properties'].append(cyclonedx_common.get_property('tern:repotag', repotag))
+
+    os_guess = cyclonedx_common.get_os_guess(image_obj)
+    if os_guess:
+        image_dict['properties'].append(cyclonedx_common.get_property('tern:os_guess', os_guess))
+
+    cdx_hash = cyclonedx_common.get_hash(image_obj.checksum_type, image_obj.checksum)
+    if cdx_hash is not None:
+        image_dict['hashes'].append(cdx_hash)
+
+    return image_dict

--- a/tern/formats/cyclonedx/cyclonedxjson/package_helpers.py
+++ b/tern/formats/cyclonedx/cyclonedxjson/package_helpers.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021 Patrick Dwyer. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+'''
+Helper functions for packages in CycloneDX JSON document creation
+'''
+
+from tern.formats.cyclonedx import cyclonedx_common
+from packageurl import PackageURL
+
+
+def get_package_dict(os_guess, package):
+    ''' Given a package format, namespace and package object return a
+    CycloneDX JSON dictionary representation of the package. '''
+    package_dict = {
+        'name': package.name,
+        'version': package.version,
+        'type': 'application',
+    }
+
+    purl_type = package.pkg_format
+    purl_namespace = cyclonedx_common.get_purl_namespace(os_guess, package.pkg_format)
+    if purl_type:
+        purl = PackageURL(purl_type, purl_namespace, package.name, package.version)
+        package_dict['purl'] = str(purl)
+
+    if package.pkg_license:
+        package_dict['licenses'] = [cyclonedx_common.get_license_from_name(package.pkg_license)]
+
+    if package.pkg_licenses:
+        package_dict['evidence'] = {'licenses': []}
+        for pkg_license in package.pkg_licenses:
+            package_dict['evidence']['licenses'].append(cyclonedx_common.get_license_from_name(pkg_license))
+
+    return package_dict
+
+
+def get_packages_list(image_obj):
+    ''' Given an image object return a list of CycloneDX dictionary
+    representations for each of the packages in the image '''
+    package_dicts = []
+
+    os_guess = cyclonedx_common.get_os_guess(image_obj)
+
+    for layer_obj in image_obj.layers:
+        for package in layer_obj.packages:
+            package_dicts.append(get_package_dict(os_guess, package))
+
+    return package_dicts


### PR DESCRIPTION
Demo support for #987 

There's heaps missing from this. Just implemented the absolute basics.

A few issues (while they are fresh in my mind):

- will have duplicated components across layers
- no bom-refs or dependency graph/composition completeness
- purl is not correctly generated and only generated for deb packages
- files are omitted (although I question the need to include them outside of OSS license compliance use cases, which SPDX output already covers)
- demonstrated custom properties with `repotags`, but plenty of extra tern metadata has not been captured
- and probably some other basic stuff that I haven't quite got right in terms of project code consistency, etc