### PR TITLE
Fix: Ignore newlines in os_release file

### DIFF
--- a/tern/analyze/default/container/single_layer.py
+++ b/tern/analyze/default/container/single_layer.py
@@ -45,8 +45,10 @@ def find_os_release(host_path):
     # Create dictionary from os-release values
     os_release_dict = {}
     for line in lines:
-        key, val = line.rstrip().split('=', 1)
-        os_release_dict[key] = val.strip('"')
+        line = line.strip()
+        if line:
+            key, val = line.split('=', 1)
+            os_release_dict[key] = val.strip('"')
     pretty_name = ''
     if "PRETTY_NAME" in os_release_dict.keys():
         if os_release_dict["PRETTY_NAME"] == "Distroless":


### PR DESCRIPTION
Previously, we strip any newlines and split the string on "=".
However, if the string is empty then only one value is returned.
Hence we first strip any whitespace or newline characters in each
line, and then we check if the line is a non-empty string before
splitting it into key and value based on the "=" separator.

Signed-off-by: Nisha K <nishak@vmware.com>