### PR TITLE
fix: Pass the redo flag to the executor

### DIFF
--- a/tern/extensions/scancode/executor.py
+++ b/tern/extensions/scancode/executor.py
@@ -194,7 +194,7 @@ class Scancode(Executor):
         '''
         for layer in image_obj.layers:
             # load the layers from cache
-            common.load_from_cache(layer)
+            common.load_from_cache(layer, redo)
             if redo or not layer.files_analyzed:
                 # the layer doesn't have analyzed files, so run analysis
                 file_list, package_list = collect_layer_data(layer)


### PR DESCRIPTION
If the redo flag is set, the executor should not load data from
the cache. Hence we pass the redo flag to the load_from_cache
function used in the scancode executor.

Fixes #999

Signed-off-by: Nisha K <nishak@vmware.com>