### PR TITLE
Remove `/` from image SPDX Identifier Reference

### DIFF
--- a/tern/classes/image.py
+++ b/tern/classes/image.py
@@ -184,6 +184,9 @@ class Image:
         and this is currently not supported by any image tool. So using
         a combination of name and tag or name and checksum instead'''
         name = self.name
+        # SPDX does not allow '/' character to be used in SPDX ID References
+        if "/" in self.name:
+            name = name.replace("/", "-")
         if self.tag:
             name = name + '-{}'.format(self.tag)
         elif self.checksum:


### PR DESCRIPTION
Currently, Tern uses `image_name-tag` or `image_name-checksum` to render a
human readable ID for an image's SPDXRef in SPDX documents. This is
problematic when there is a `/` character in the image name, in which
case, the SPDX document fails to verify because the SPDXRef does not
meet the SPDX Identifier Reference requirements [1]. This commit
replaces the `/` character in an image name with a `-`.

[1] https://spdx.github.io/spdx-spec/8-annotations/#84-spdx-identifier-reference

Signed-off-by: Rose Judge <rjudge@vmware.com>