### PR TITLE
Fix: duplicate scancode files being reported

### DIFF
--- a/tern/extensions/scancode/executor.py
+++ b/tern/extensions/scancode/executor.py
@@ -166,13 +166,16 @@ def add_file_data(layer_obj, collected_files):
     # the file level data already in the layer object
     logger.debug("Collecting file data...")
     while collected_files:
+        merged = False
         checkfile = collected_files.pop()
         for f in layer_obj.files:
-            if f.merge(checkfile):
+            merged = f.merge(checkfile)
+            if merged:
                 # file already exists and has now been updated
                 break
-        # file didn't previously exist in layer so add it now
-        layer_obj.files.append(checkfile)
+        if not merged:
+            # file didn't previously exist in layer so add it now
+            layer_obj.files.append(checkfile)
 
 
 def add_package_data(layer_obj, collected_packages):


### PR DESCRIPTION
When running scancode with an empty cache, Tern was reporting the same
file twice due to a logic bug in the add_file_data() function. This fix
adds a flag to ensure that a file is only added to the layer object
file list if it does not already exist there.

Resolves #1000

Signed-off-by: Rose Judge <rjudge@vmware.com>