### PR TITLE
Add cyclonedxjson to help menu

### DIFF
--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -196,7 +196,8 @@ def main():
                                metavar='REPORT_FORMAT',
                                help="Format the report using one of the "
                                "available formats: "
-                               "spdxtagvalue, spdxjson, json, yaml, html")
+                               "spdxtagvalue, spdxjson, cyclonedxjson, json, "
+                               "yaml, html")
     parser_report.add_argument('-o', '--output-file', default=None,
                                metavar='FILE',
                                help="Write the report to a file. "


### PR DESCRIPTION
This small commit adds a hint to the report help menu that cylonedxjson
is available as a report format.

Signed-off-by: Rose Judge <rjudge@vmware.com>