### PR TITLE
Fix CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Tern](/docs/img/tern_logo.png)
 
-[![GitHub Actions](https://github.com/tern-tools/tern/workflows/Pull%20Request%20Lint%20and%20Test/badge.svg?branch=master)](https://github.com/tern-tools/tern/actions)
+[![Pull Request Lint and Test](https://github.com/tern-tools/tern/actions/workflows/pull_request.yml/badge.svg)](https://github.com/tern-tools/tern/actions/workflows/pull_request.yml)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2689/badge)](https://bestpractices.coreinfrastructure.org/projects/2689)
 [![License](https://img.shields.io/badge/License-BSD%202--Clause-orange.svg)](https://opensource.org/licenses/BSD-2-Clause)
 


### PR DESCRIPTION
The previous badge says `no status` for some reason.

This version was copied from https://github.com/tern-tools/tern/actions/workflows/pull_request.yml -> click the three dots -> `Create status badge`.