### PR TITLE
Direct check for key in os_release_dict

### DIFF
--- a/tern/analyze/default/container/single_layer.py
+++ b/tern/analyze/default/container/single_layer.py
@@ -50,7 +50,7 @@ def find_os_release(host_path):
             key, val = line.split('=', 1)
             os_release_dict[key] = val.strip('"')
     pretty_name = ''
-    if "PRETTY_NAME" in os_release_dict.keys():
+    if "PRETTY_NAME" in os_release_dict:
         if os_release_dict["PRETTY_NAME"] == "Distroless":
             pretty_name = "{0} - {1}".format(os_release_dict["PRETTY_NAME"],
                                              os_release_dict['VERSION'])


### PR DESCRIPTION
The find_os_release function parses an os_release file into a dictionary
so the "PRETTY_NAME" can be extracted from it. Rather than checking for
"PRETTY_NAME" in the dictionary's keys, we iterate over the dictionary
directly to improve performance.

Resolves #1043

Signed-off-by: Hannah Lumapas <lumapas.h@gmail.com>