### PR TITLE
Tern currently reports the package download location in SPDX reports

### DIFF
--- a/tern/formats/spdx/spdxtagvalue/layer_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/layer_helpers.py
@@ -113,7 +113,7 @@ def get_layer_block(layer_obj, template):
     # Package File Name
     block += 'PackageFileName: {}\n'.format(layer_obj.tar_file)
     # Package Download Location (always NONE for layers)
-    block += 'PackageDownloadLocation: NONE\n'
+    block += 'PackageDownloadLocation: NOASSERTION\n'
     # Files Analyzed
     if layer_obj.files_analyzed:
         # we need a package verification code

--- a/tern/formats/spdx/spdxtagvalue/package_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/package_helpers.py
@@ -47,7 +47,7 @@ def get_package_block(package_obj, template):
         block += 'PackageDownloadLoaction: {}\n'.format(
             mapping['PackageDownloadLocation'])
     else:
-        block += 'PackageDownloadLocation: NONE\n'
+        block += 'PackageDownloadLocation: NOASSERTION\n'
     # Files Analyzed (always false for packages)
     block += 'FilesAnalyzed: false\n'
     # Package License Concluded (always NOASSERTION)


### PR DESCRIPTION
Tern currently reports the package download location in SPDX reports as NONE. In the recent SPDX DocFest, it was discussed that the value should actually be NOASSERTION.

Resolves #1038

Signed-off-by: Jamila Ritter jamilaritter@hotmail.com