### PR TITLE
Direct check for key in command['base'] dictionary

### DIFF
--- a/tern/analyze/default/command_lib/command_lib.py
+++ b/tern/analyze/default/command_lib/command_lib.py
@@ -57,7 +57,7 @@ class FormatAwk(dict):
 def get_base_listing(key):
     '''Given the key listing in base.yml, return the dictionary'''
     listing = {}
-    if key in command_lib['base'].keys():
+    if key in command_lib['base']:
         listing = copy.deepcopy(command_lib['base'][key])
     else:
         logger.warning("%s", errors.no_listing_for_base_key.format(


### PR DESCRIPTION
The get_base_listing function checks if a specific key exists
in the command_lib['base'] dictionary. Rather than checking the
return value of command_lib['base'].keys() we directly check the
command_lib['base'] dictionary to improve performance.

Resolves: #1040

Signed-off-by: Debbie Leung <dsl2162@columbia.edu>