### PR TITLE
Fix: #1042 check_sourcable function

### DIFF
--- a/tern/analyze/default/command_lib/command_lib.py
+++ b/tern/analyze/default/command_lib/command_lib.py
@@ -179,12 +179,12 @@ def check_sourcable(command, package_name):
     If the package has a url or source retrieval steps associated with it
     then we return True. If not then we return false'''
     sourcable = False
-    if command in command_lib['snippets'].keys():
+    if command in command_lib['snippets']:
         for package in command_lib['snippets'][command]['packages']:
             if package['name'] == package_name or \
                     package['name'] == 'default':
-                if 'url' in package.keys() or \
-                        'src' in package.keys():
+                if 'url' in package or \
+                        'src' in package:
                     sourcable = True
     return sourcable
 


### PR DESCRIPTION
The check_sourcable function was modified to checks for keys directly against the dictionaries. The change was made to iterate  through various dictionaries rather than calling the keys() function

Resolves: #1042

Signed-off-by: Jindu Okoli <jokoli@juniper.net>