### PR TITLE
Change SPDX pkg download location to NOASSERTION

### DIFF
--- a/tern/formats/spdx/spdxjson/package_helpers.py
+++ b/tern/formats/spdx/spdxjson/package_helpers.py
@@ -33,7 +33,7 @@ def get_package_dict(package, template):
         'versionInfo': mapping['PackageVersion'] if mapping['PackageVersion']
         else 'NOASSERTION',
         'downloadLocation': mapping['PackageDownloadLocation'] if
-        mapping['PackageDownloadLocation'] else 'NONE',
+        mapping['PackageDownloadLocation'] else 'NOASSERTION',
         'filesAnalyzed': 'false',  # always false for packages
         'licenseConcluded': 'NOASSERTION',  # always NOASSERTION
         'licenseDeclared': spdx_common.get_license_ref(


### PR DESCRIPTION
Tern currently reports the package download location in SPDX JSON
reports as NONE. In the recent SPDX DocFest, it was discussed that
the value should actually be NOASSERTION.

Resolves #1039

Signed-off-by: Kerin Pithawala kerinpithawala7@gmail.com