### PR TITLE
Add OpossumUI output report format

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ tern.formats =
     yaml = tern.formats.yaml.generator:YAML
     html = tern.formats.html.generator:HTML
     cyclonedxjson = tern.formats.cyclonedx.cyclonedxjson.generator:CycloneDXJSON
+    opossumui = tern.formats.opossumui.generator:OpossumUI
 tern.extensions =
     cve_bin_tool = tern.extensions.cve_bin_tool.executor:CveBinTool
     scancode = tern.extensions.scancode.executor:Scancode

--- a/tern/analyze/default/bundle.py
+++ b/tern/analyze/default/bundle.py
@@ -67,7 +67,7 @@ def convert_to_pkg_dicts(attr_lists):
     return pkg_list
 
 
-def fill_pkg_results(image_layer, pkg_list_dict, pkg_format):
+def fill_pkg_results(image_layer, pkg_list_dict, pkg_format, source):
     """Fill results from collecting package information into the image layer
     object"""
     if 'names' in pkg_list_dict and len(pkg_list_dict['names']) > 1:
@@ -76,4 +76,5 @@ def fill_pkg_results(image_layer, pkg_list_dict, pkg_format):
             pkg = Package(pkg_dict['name'])
             pkg.fill(pkg_dict)
             pkg.pkg_format = pkg_format
+            pkg.source = source
             image_layer.add_package(pkg)

--- a/tern/analyze/default/core.py
+++ b/tern/analyze/default/core.py
@@ -78,7 +78,8 @@ def execute_base(layer_obj, prereqs):
         if warnings:
             logger.warning("Some metadata may be missing")
         # bundle the results into Package objects
-        bundle.fill_pkg_results(layer_obj, pkg_dict, listing.get("pkg_format"))
+        bundle.fill_pkg_results(layer_obj, pkg_dict, listing.get("pkg_format"),
+                                prereqs.binary)
         # remove extra FileData objects from the layer
         com.remove_duplicate_layer_files(layer_obj)
     # if there is no listing add a notice

--- a/tern/analyze/default/live/run.py
+++ b/tern/analyze/default/live/run.py
@@ -84,7 +84,8 @@ def fill_packages(layer, prereqs):
                          "metadata.")
         if warnings:
             logger.warning("Some metadata may be missing.")
-        bundle.fill_pkg_results(layer, pkg_dict, listing.get("pkg_format"))
+        bundle.fill_pkg_results(layer, pkg_dict, listing.get("pkg_format"),
+                                prereqs.binary)
         com.remove_duplicate_layer_files(layer)
 
 

--- a/tern/classes/file_data.py
+++ b/tern/classes/file_data.py
@@ -39,6 +39,7 @@ class FileData:
         urls: a list of urls from where this file could come from
         checksums: a dictionary of the form {<checksum_type>: <checksum>,...}
         checksum types and checksums are stored in lower case
+        source: tool or utility that collected package metadata
 
     methods:
         to_dict: returns a dictionary representation of the instance
@@ -71,6 +72,7 @@ class FileData:
         self.urls = []
         self.__checksums = {}
         self.__origins = Origins()
+        self.__source = ''
 
     @property
     def name(self):
@@ -149,6 +151,14 @@ class FileData:
     @property
     def origins(self):
         return self.__origins
+
+    @property
+    def source(self):
+        return self.__source
+
+    @source.setter
+    def source(self, source):
+        self.__source = source
 
     def set_checksum(self, checksum_type='', checksum=''):
         '''Set the checksum type and checksum of the file'''

--- a/tern/classes/package.py
+++ b/tern/classes/package.py
@@ -22,6 +22,7 @@ class Package:
         checksum: checksum as package property
         files: list of files in a package
         pkg_licenses: all licenses found within a package
+        source: tool or utility that collected package metadata
 
     methods:
         to_dict: returns a dict representation of the instance
@@ -43,6 +44,7 @@ class Package:
         self.__files = []
         self.__pkg_licenses = []
         self.__pkg_format = ''
+        self.__source = ''
 
     @property
     def name(self):
@@ -123,6 +125,14 @@ class Package:
     @pkg_format.setter
     def pkg_format(self, pkg_format):
         self.__pkg_format = pkg_format
+
+    @property
+    def source(self):
+        return self.__source
+
+    @source.setter
+    def source(self, source):
+        self.__source = source
 
     def get_file_paths(self):
         """Return a list of paths of all the files in a package"""

--- a/tern/extensions/scancode/executor.py
+++ b/tern/extensions/scancode/executor.py
@@ -67,6 +67,7 @@ def get_scancode_file(file_dict):
         fd.urls = [u['url'] for u in file_dict['urls']]
     fd.packages = file_dict['packages']
     fd.authors = [a['value'] for a in file_dict['authors']]
+    fd.source = "Scancode"
     if file_dict['scan_errors']:
         # for each scan error make a notice
         for err in file_dict['scan_errors']:
@@ -112,6 +113,7 @@ def get_scancode_package(package_dict):
     package.download_url = package_dict['download_url']
     package.licenses = [package_dict['declared_license'],
                         package_dict['license_expression']]
+    package.source = "Scancode"
     return package
 
 

--- a/tern/formats/opossumui/__init__.py
+++ b/tern/formats/opossumui/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause

--- a/tern/formats/opossumui/generator.py
+++ b/tern/formats/opossumui/generator.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+OpossumUI Generator document
+"""
+
+import json
+import logging
+
+from tern.formats.spdx import spdx_common
+from tern.utils.general import get_git_rev_or_version
+from tern.utils import constants
+from tern.formats import generator
+from tern.report import content
+
+
+# global logger
+logger = logging.getLogger(constants.logger_name)
+
+
+def get_resources(image_obj):
+    '''Packages in each layer will be mapped to:
+        /Layer_00x/Packages/pkg_source/pkg_name'''
+    resources = {}
+    for layer in image_obj.layers:
+        resources["Layer_{}".format('%03d' % layer.layer_index)] = \
+            {"Packages": {pkg.source: {
+                p.name: 1 for p in layer.packages if p.source == pkg.source}
+                for pkg in layer.packages}}
+    return resources
+
+
+def get_external_attrs(image_obj):
+    '''Create a dict which contains attribution information about a file or
+    folder. The key is the uuid of the package and the value is a dictionary
+    of metadata'''
+    external_attrs = {}
+    image_uuids = {}
+    for layer in image_obj.layers:
+        for pkg in layer.packages:
+            pkg_uuid = spdx_common.get_uuid()
+            if layer.layer_index in image_uuids.keys():
+                try:
+                    # See if source exists in layer
+                    image_uuids[layer.layer_index][pkg.source].append(pkg_uuid)
+                except KeyError:
+                    # If not, add the new source to existing layer
+                    image_uuids[layer.layer_index][pkg.source] = [pkg_uuid]
+            else:
+                # add new layer and source
+                image_uuids[layer.layer_index] = {pkg.source: [pkg_uuid]}
+            pkg_comment = ''
+            if pkg.origins.origins:
+                for notice_origin in pkg.origins.origins:
+                    pkg_comment = pkg_comment + content.print_notices(
+                        notice_origin, '', '\t')
+            # Debian will have a pkg_licenses value but not license
+            pkg_license = pkg.pkg_license if pkg.pkg_license else \
+                ''.join(pkg.pkg_licenses)
+            external_attrs[pkg_uuid] = {
+                "source": {
+                    "name": pkg.source,
+                    "documentConfidence": int(70.0)
+                },
+                "comment": pkg_comment,
+                "packageName": pkg.name,
+                "packageVersion": pkg.version if pkg.version else "NONE",
+                "url": pkg.proj_url,
+                "licenseName": pkg_license if pkg_license else "NONE",
+                "copyright": pkg.copyright if pkg.copyright else "NONE"
+            }
+    return external_attrs, image_uuids
+
+
+def get_resource_attrs(uuids):
+    '''Return the dictionary that maps a [package] path in the resource tree
+    to a list of externalAttribution uuid string(s):
+        {"/path/to/resource/": [<list of resource uuids>]}'''
+    resource_attrs = {}
+    for layer, layer_uuids in uuids.items():
+        for source, pkg_uuids in layer_uuids.items():
+            resource_attrs["/Layer_{}/Packages/{}/".format(
+                '%03d' % layer, source)] = pkg_uuids
+    return resource_attrs
+
+
+def get_attr_breakpoints(image_obj):
+    '''We list pacakges in each layer under the Layer_00x/Packages/source
+    directory but that is not the literal path. Hence, we add
+    Layer_00x/Packages/ for each layer as an attribution breakpoint.
+    '''
+    attr_breakpoints = []
+    for layer in image_obj.layers:
+        attr_breakpoints.append("/Layer_{}/Packages/".format(
+            '%03d' % layer.layer_index))
+    return attr_breakpoints
+
+
+def get_document_dict(image_obj):
+    '''Return a dictionary that maps the following fields:
+        metadata: containers project-level information
+        resources: defines the file tree
+        externalAttributions: contains attributions provided as signals
+        resourcesToAttributions: links attributions to file paths
+        attributionBreakpoints: Folders where the attribution inference stops.
+        '''
+    docu_dict = {
+        "metadata": {
+            "projectId": get_git_rev_or_version()[1],
+            "projectTitle": "Tern report for {}".format(image_obj.name),
+            "fileCreationDate": spdx_common.get_timestamp()
+        }
+    }
+
+    docu_dict["resources"] = get_resources(image_obj)
+    docu_dict["externalAttributions"], uuids = get_external_attrs(image_obj)
+    docu_dict["resourcesToAttributions"] = get_resource_attrs(uuids)
+    docu_dict["attributionBreakpoints"] = get_attr_breakpoints(image_obj)
+    return docu_dict
+
+
+class OpossumUI(generator.Generate):
+    def generate(self, image_obj_list, print_inclusive=False):
+        logger.debug("Generating OpossumUI document...")
+        image_obj = image_obj_list[0]
+        report = get_document_dict(image_obj)
+        return json.dumps(report)


### PR DESCRIPTION
This commit adds a new output format for OpossumUI[1]. The OpossumUI
format can be generated by invoking `tern report -i <image> -f
opossumui`
on the command line. The format follows the OpossumUI JSON
schema and, once generated, can be used to visually represent Tern's
findings in a UI. Once a file is open in the UI, SBOM data can be
verifed or edited as necessary.

This commit also adds `source` as a property of the file_data and package
classes. The source of a file or package is the package manager or metadata
collection utility. This information can be helpful in determining the
trustworthiness of the collection method. This is also helpful when it comes
to generating OpossumUI output files as each package and file needs to be
associated with a source.

[1] https://github.com/opossum-tool/OpossumUI

Signed-off-by: Rose Judge <rjudge@vmware.com>