### PR TITLE
Scancode should run n-1 core

### DIFF
--- a/tern/extensions/scancode/executor.py
+++ b/tern/extensions/scancode/executor.py
@@ -136,7 +136,7 @@ def collect_layer_data(layer_obj):
     # run scancode against a directory
     try:
         processes = len(os.sched_getaffinity(0))
-        command = "scancode -ilpcu --quiet --timeout 300 -n {} --json -".format(processes)
+        command = "scancode -ilpcu --quiet --timeout 300 -n {} --json -".format(processes - 1)
     except (AttributeError, NotImplementedError):
         command = "scancode -ilpcu --quiet --timeout 300 --json -"
     full_cmd = get_filesystem_command(layer_obj, command)


### PR DESCRIPTION
It is recommended to run ScanCode with with
one less core than is available. Should
run n-1 core, instead of using all available
resources.

Resolves #1062

Signed-off-by: Sayantani Saha <ii.sayantani.ii@gmail.com>