### PR TITLE
Remove unused clean_image_tars function

### DIFF
--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -9,7 +9,6 @@ Create a report
 
 import logging
 import os
-import shutil
 from stevedore import driver
 from stevedore.exception import NoMatches
 
@@ -34,14 +33,6 @@ def clean_image_tars(image_obj):
         fspath = rootfs.get_untar_dir(layer.tar_file)
         if os.path.exists(fspath):
             rootfs.root_command(rootfs.remove, fspath)
-
-
-def clean_working_dir():
-    '''Clean up the working directory
-    If bind_mount is true then leave the upper level directory'''
-    path = rootfs.get_working_dir()
-    if os.path.exists(path):
-        shutil.rmtree(path)
 
 
 def generate_report(args, *images):


### PR DESCRIPTION
The clean_image_tars function in report.py
has a duplicate in prep.py which
is the function to be used when removing
image tarballs after analysis.
Hence we remove this unused function.

Resolves #1044

Signed-off by: Sayantani Saha <ii.sayantani.ii@gmail.com>