### PR TITLE
Fix for SPDX JSON format to match SPDX JSON schema

### DIFF
--- a/tern/formats/spdx/spdx.py
+++ b/tern/formats/spdx/spdx.py
@@ -11,7 +11,7 @@ class SPDX(Template):
     It provides mappings for the SPDX tag-value document format'''
 
     def file_data(self):
-        return {'name': 'FileName',
+        return {'path': 'FileName',
                 'short_file_type': 'FileType'}
 
     def package(self):

--- a/tern/formats/spdx/spdxjson/generator.py
+++ b/tern/formats/spdx/spdxjson/generator.py
@@ -50,8 +50,8 @@ def get_document_dict(image_obj, template):
         'creationInfo': {
             'created': json_formats.created.format(
                 timestamp=spdx_common.get_timestamp()),
-            'creators': json_formats.creator.format(
-                version=get_git_rev_or_version()[1]),
+            'creators': [json_formats.creator.format(
+                version=get_git_rev_or_version()[1])],
             'licenseListVersion': json_formats.license_list_version,
         },
         'name': json_formats.document_name.format(image_name=image_obj.name),

--- a/tern/formats/spdx/spdxjson/image_helpers.py
+++ b/tern/formats/spdx/spdxjson/image_helpers.py
@@ -81,7 +81,7 @@ def get_image_dict(image_obj, template):
         'SPDXID': spdx_common.get_image_spdxref(image_obj),
         'versionInfo': mapping['PackageVersion'],
         'downloadLocation': 'NOASSERTION',  # always NOASSERTION
-        'filesAnalyzed': 'false',  # always false
+        'filesAnalyzed': False,  # always false
         'licenseConcluded': 'NOASSERTION',  # always NOASSERTION
         'licenseDeclared': 'NOASSERTION',  # always NOASSERTION
         'copyrightText': 'NOASSERTION'  # always NOASSERTION

--- a/tern/formats/spdx/spdxjson/layer_helpers.py
+++ b/tern/formats/spdx/spdxjson/layer_helpers.py
@@ -144,9 +144,9 @@ def get_layer_dict(layer_obj):
     layer_dict = {
         'name': os.path.basename(layer_obj.tar_file),
         'SPDXID': spdx_common.get_layer_spdxref(layer_obj),
-        'fileName': layer_obj.tar_file,
+        'packageFileName': layer_obj.tar_file,
         'downloadLocation': 'NONE',
-        'filesAnalyzed': 'true' if layer_obj.files_analyzed else 'false',
+        'filesAnalyzed': bool(layer_obj.files_analyzed),
         'checksums': [{
             'algorithm':
                 spdx_common.get_layer_checksum(layer_obj).split(

--- a/tern/formats/spdx/spdxjson/package_helpers.py
+++ b/tern/formats/spdx/spdxjson/package_helpers.py
@@ -34,7 +34,7 @@ def get_package_dict(package, template):
         else 'NOASSERTION',
         'downloadLocation': mapping['PackageDownloadLocation'] if
         mapping['PackageDownloadLocation'] else 'NOASSERTION',
-        'filesAnalyzed': 'false',  # always false for packages
+        'filesAnalyzed': False,  # always false for packages
         'licenseConcluded': 'NOASSERTION',  # always NOASSERTION
         'licenseDeclared': spdx_common.get_license_ref(
             mapping['PackageLicenseDeclared']) if
@@ -62,7 +62,7 @@ def get_packages_list(image_obj, template):
             # Create a list of dictionaries. Each dictionary represents
             # one package object in the image
             pkg_ref = spdx_common.get_package_spdxref(package)
-            if pkg_ref not in package_refs:
+            if pkg_ref not in package_refs and package.name:
                 package_dicts.append(get_package_dict(package, template))
                 package_refs.add(pkg_ref)
     return package_dicts

--- a/tern/formats/spdx/spdxtagvalue/image_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/image_helpers.py
@@ -92,7 +92,7 @@ def get_image_block(image_obj, template):
     # Package Download Location (always NOASSERTION)
     block += 'PackageDownloadLocation: NOASSERTION\n'
     # Files Analyzed (always false)
-    block += 'FilesAnalyzed: false\n'
+    block += 'FilesAnalyzed: {}\n'.format(False)
     # Concluded Package License (always NOASSERTION)
     block += 'PackageLicenseConcluded: NOASSERTION\n'
     # Declared Package License (always NOASSERTION)


### PR DESCRIPTION
The SPDX JSON format was not validating against the SPDX JSON
schema[1]. In particular, there were four main validation isssues
fixed with this commit:

1) creationInfo.creations was being reported as a string and the schema
expects an array.
2) packages.filesAnalyzed was being reported as the string `false`
instead of a boolean `False` value.
3) Packages were referred to using the key `fileName` instead
of `packageFileName`.
4) Packages were being reported without a `name` value (i.e. some
`name`s were reported as `null`)

This commit also changes the spdx[*] format to report  file names as the
full path of the file instead of just the file name. This is because the
SPDX spec describes the fileName value as: "The name of the file
relative to the root of the package."

[1] https://github.com/spdx/spdx-spec/blob/v2.2.1/schemas/spdx-schema.json

Resolves #1064

Signed-off-by: Rose Judge <rjudge@vmware.com>