### PR TITLE
Add DockerException when daemon not running

### DIFF
--- a/tern/load/docker_api.py
+++ b/tern/load/docker_api.py
@@ -31,9 +31,9 @@ def check_docker_setup():
         client = docker.from_env(timeout=180)
         client.ping()
         return client
-    except requests.exceptions.ConnectionError as e:
+    except (requests.exceptions.ConnectionError, docker.errors.DockerException) as e:
         logger.critical('Critical Docker error: %s', str(e))
-        if 'FileNotFoundError' in str(e):
+        if 'FileNotFoundError' in str(e) or 'ConnectionRefusedError' in str(e):
             logger.critical('Docker is not installed or the daemon is not '
                             'running.')
         if 'PermissionError' in str(e):


### PR DESCRIPTION
If the docker service and docker.socket service are disabled, a
DockerException error is thrown when Tern tries to connect using the
default socket. This commit adds an exception for the DockerException
in addition to the current requests ConnectionError exception so that
Tern exits gracefully if the docker dameon is not running instead of
printing the DockerError traceback to the console.

Resolves #1073

Signed-off-by: Rose Judge <rjudge@vmware.com>