### PR TITLE
DO NOT MERGE: check if labeled tag works

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,5 +1,7 @@
 name: Pull Request Lint and Test
-on: pull_request
+on:
+  pull_request:
+    types: [ labeled ]
 
 jobs:
   Prospector_Linting:


### PR DESCRIPTION
This commit is a test to see if the "labeled" type works to prevent CI
workflow runs when a PR is not labeled by a maintainer with write
access.

Signed-off-by: Rose Judge <rjudge@vmware.com>