### PR TITLE
Add SPDX "document DESCRIBES image" relationship

### DIFF
--- a/tern/formats/spdx/spdxtagvalue/formats.py
+++ b/tern/formats/spdx/spdxtagvalue/formats.py
@@ -31,6 +31,7 @@ package_id = '{name}-{ver}'
 # Relationship strings
 contains = 'Relationship: {outer} CONTAINS {inner}'
 prereq = 'Relationship: {after} HAS_PREREQUISITE {before}'
+describes = 'Relationship: {doc} DESCRIBES {image}'
 
 # License Reference Information
 license_id = 'LicenseID: {license_ref}'

--- a/tern/formats/spdx/spdxtagvalue/image_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/image_helpers.py
@@ -102,6 +102,9 @@ def get_image_block(image_obj, template):
     # blank line
     block += '\n'
     # Since files are not analyzed within the image we move to relationships
+    block += spdx_formats.describes.format(doc="SPDXRef-DOCUMENT",
+                                           image=spdx_common.get_image_spdxref(
+                                               image_obj)) + '\n'
     block += get_image_layer_relationships(image_obj) + '\n'
     # blank line
     block += '\n'


### PR DESCRIPTION
The SPDX spec requires at least one DESCRIBES SBOM to artifact
relationship in cases where "more than one package or set of
files (not in a package) is present". This commit adds the describes
relationship that was missing in the spdxtagvalue report.

Resolves #1079

Signed-off-by: Rose Judge <rjudge@vmware.com>