### PR TITLE
Updating setup.cfg fields

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,11 +7,11 @@
 [metadata]
 name = tern
 author = VMware Inc
-author-email = nishak@vmware.com
+author_email = nishak@vmware.com
 summary = An inspection tool to find the OSS compliance metadata of the packages installed in a container image.
-long-description = file: README.md
-long-description-content-type = text/markdown; charset=UTF-8
-home-page = https://github.com/tern-tools/tern/
+long_description = file: README.md
+long_description_content_type = text/markdown; charset=UTF-8
+home_page = https://github.com/tern-tools/tern/
 project_urls =
     Documentation = https://github.com/tern-tools/tern/tree/master/docs
     Source Code = https://github.com/tern-tools/tern 


### PR DESCRIPTION
The current setup.cfg has several fields with dashes (-) that will soon be deprecated. The warning message alerts to change these to underscores!

This will close #1084 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>