### PR TITLE
Enable Tern to run in an unprivileged container

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,39 +1,32 @@
-# Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-FROM debian:buster
+FROM python:3.9-slim-buster as base
 
-# Install fuse-overlayfs and Tern dependencies
-RUN apt-get update && \
-    apt-get -y install \
-    attr \
-    findutils \
-    git \
-    gnupg2 \
-    jq \
-    python3 \
-    python3-pip \
-    python3-setuptools \
-    tar \
-    util-linux \
-    wget && \
-    echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_10/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list && \
-    wget --no-verbose https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/Debian_10/Release.key -O - | apt-key add - && \
-    apt-get update && \
-    apt-get -y install \
-    buildah \
-    fuse-overlayfs && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+FROM base as builder
 
-# Adjust storage.conf to enable Fuse storage.
-RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' /etc/containers/storage.conf
+RUN mkdir /install
+WORKDIR /install
 
-# Install tern with latest changes
 COPY dist/tern-*.tar.gz .
-RUN pip3 install --upgrade pip && \
-    pip3 install --no-cache-dir \
+RUN pip install --no-warn-script-location --prefix=/install \
     tern-*.tar.gz
 
-ENTRYPOINT ["tern", "--driver", "fuse"]
-CMD ["-h"]
+FROM base
+
+RUN echo "deb http://deb.debian.org/debian bullseye main" > /etc/apt/sources.list.d/bullseye.list \
+    && echo "Package: *\nPin: release n=bullseye\nPin-Priority: 50" > /etc/apt/preferences.d/bullseye \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+    attr \
+    findutils \
+    fuse-overlayfs/bullseye \
+    fuse3/bullseye \
+    git \
+    jq \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /install /usr/local
+
+ENTRYPOINT ["tern"]
+CMD ["--help"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 FROM python:3.9-slim-buster as base
@@ -27,5 +27,5 @@ RUN echo "deb http://deb.debian.org/debian bullseye main" > /etc/apt/sources.lis
 
 COPY --from=builder /install /usr/local
 
-ENTRYPOINT ["tern", "--driver", "fuse"]
+ENTRYPOINT ["tern"]
 CMD ["--help"]

--- a/docker/Dockerfile.scancode
+++ b/docker/Dockerfile.scancode
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 FROM python:3.9-slim-buster as base
@@ -34,5 +34,5 @@ RUN echo "deb http://deb.debian.org/debian bullseye main" > /etc/apt/sources.lis
 
 COPY --from=builder /install /usr/local
 
-ENTRYPOINT ["tern", "--driver", "fuse"]
+ENTRYPOINT ["tern"]
 CMD ["--help"]

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 #
 # Script to run Tern within a prebuilt Docker container
@@ -11,4 +11,4 @@
 # Usage: ./docker_run.sh <tern image> <tern command arguments in quotes> > output.txt
 # Example: ./docker_run.sh ternd "report -i golang:alpine" > output.txt
 
-docker run --privileged --device /dev/fuse -v /var/run/docker.sock:/var/run/docker.sock --rm $1 $2
+docker run -v /var/run/docker.sock:/var/run/docker.sock --rm $1 $2

--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -145,11 +145,12 @@ def main():
                         help="Change default working directory to specified"
                         " absolute path.")
     parser.add_argument('-dr', '--driver', metavar="DRIVER_OPTION",
-                        help="Required when running Tern in a container."
-                        "Using 'fuse' will enable the fuse-overlayfs driver "
-                        "to mount the diff layers of the container. If no "
-                        "input is provided, 'fuse' will be used as the "
-                        "default option.")
+                        default='default',
+                        help="Choose from the following storage drivers: \n"
+                        "overlay2: Use the kernel's overlay2 storage driver\n"
+                        "fuse: Use the fuse-overlayfs system tool\n"
+                        "If no option is given, the default method of "
+                        "applying container layers in userspace will be used.")
 
     # sys.version gives more information than we care to print
     py_ver = sys.version.replace('\n', '').split('[', maxsplit=1)[0]

--- a/tern/analyze/default/container/multi_layer.py
+++ b/tern/analyze/default/container/multi_layer.py
@@ -78,7 +78,6 @@ def fresh_analysis(image_obj, curr_layer, prereqs, options):
     else:
         # fall back to executing what we know
         core.execute_base(image_obj.layers[curr_layer], prereqs)
-    rootfs.undo_mount()
     rootfs.unmount_rootfs()
 
 

--- a/tern/analyze/default/debug/run.py
+++ b/tern/analyze/default/debug/run.py
@@ -45,7 +45,7 @@ def mount_container_image(image_obj, driver=None):
             image_obj, len(image_obj.layers) - 1, driver)
         rootfs.prep_rootfs(target)
     else:
-        single_layer.mount_first_layer(image_obj.layers[0])
+        single_layer.prep_first_layer(image_obj.layers[0])
 
 
 def look_up_lib(keys):
@@ -107,8 +107,7 @@ def drop_into_layer(image_obj, layer_index):
     rootfs.set_up()
     if layer_index == 0:
         # mount only one layer
-        target = rootfs.mount_base_layer(
-            image_obj.layers[layer_index].tar_file)
+        target = rootfs.prep_base_layer(image_obj.layers[layer_index].tar_file)
     else:
         # mount all layers uptil the provided layer index
         target = multi_layer.mount_overlay_fs(image_obj, layer_index)
@@ -138,7 +137,6 @@ def execute_invoke(image_obj, args):
     # invoke commands in chroot
     invoke_script(args)
     # undo the mounts
-    rootfs.undo_mount()
     rootfs.unmount_rootfs()
     # cleanup
     rootfs.clean_up()
@@ -179,10 +177,6 @@ def execute_step(image_obj, args):
 
 def recover():
     """Undo all the mounts and clean up directories"""
-    try:
-        rootfs.undo_mount()
-    except subprocess.CalledProcessError:
-        pass
     try:
         rootfs.unmount_rootfs()
     except subprocess.CalledProcessError:

--- a/tern/analyze/default/debug/run.py
+++ b/tern/analyze/default/debug/run.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2020 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 """
@@ -41,7 +41,7 @@ def check_image_obj(image_string):
 def mount_container_image(image_obj, driver=None):
     """Mount the container image to make it ready to invoke scripts"""
     if len(image_obj.layers) > 1:
-        target = multi_layer.mount_overlay_fs(
+        target = multi_layer.prep_layers(
             image_obj, len(image_obj.layers) - 1, driver)
         rootfs.prep_rootfs(target)
     else:
@@ -106,11 +106,10 @@ def drop_into_layer(image_obj, layer_index):
     upto the specified layer index and drop into a shell session"""
     rootfs.set_up()
     if layer_index == 0:
-        # mount only one layer
         target = rootfs.prep_base_layer(image_obj.layers[layer_index].tar_file)
     else:
         # mount all layers uptil the provided layer index
-        target = multi_layer.mount_overlay_fs(image_obj, layer_index)
+        target = multi_layer.prep_layers(image_obj, layer_index)
     mount_path = get_mount_path()
     print("\nWorking directory is: {}\n".format(mount_path))
     # check if there is a shell

--- a/tern/classes/file_data.py
+++ b/tern/classes/file_data.py
@@ -39,6 +39,7 @@ class FileData:
         urls: a list of urls from where this file could come from
         checksums: a dictionary of the form {<checksum_type>: <checksum>,...}
         checksum types and checksums are stored in lower case
+        is_whiteout: True if the file is a whiteout file
 
     methods:
         to_dict: returns a dictionary representation of the instance
@@ -71,6 +72,7 @@ class FileData:
         self.urls = []
         self.__checksums = {}
         self.__origins = Origins()
+        self.__is_whiteout = False
 
     @property
     def name(self):
@@ -149,6 +151,10 @@ class FileData:
     @property
     def origins(self):
         return self.__origins
+
+    @property
+    def is_whiteout(self):
+        return self.__is_whiteout
 
     def set_checksum(self, checksum_type='', checksum=''):
         '''Set the checksum type and checksum of the file'''
@@ -271,3 +277,9 @@ class FileData:
             return False
         return (self.name == other.name and self.path == other.path and
                 self.checksum == other.checksum)
+
+    def set_whiteout(self):
+        """Based on the file prefix, set whether the file is
+        a whiteout file"""
+        if '.wh.' in self.name:
+            self.__is_whiteout = True

--- a/tern/classes/image_layer.py
+++ b/tern/classes/image_layer.py
@@ -322,6 +322,7 @@ class ImageLayer:
                                  os.path.relpath(file_info[2], '.'))
             file_data.set_checksum('sha256', file_info[1])
             file_data.extattrs = file_info[0]
+            file_data.set_whiteout()
             self.add_file(file_data)
 
     def get_layer_workdir(self):

--- a/tern/prep.py
+++ b/tern/prep.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2020 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 """
@@ -9,6 +9,7 @@ Environment prep before analysis and cleanup after
 
 import logging
 import os
+import pkg_resources
 import shutil
 
 from tern.utils import constants
@@ -32,6 +33,9 @@ def setup(working_dir=None):
     rootfs.set_working_dir(working_dir)
     # load the cache
     cache.load()
+    # required to run in a container natively on Windows
+    fs_hash_path = pkg_resources.resource_filename("tern", "tools/fs_hash.sh")
+    rootfs.root_command(["chmod", "+x", fs_hash_path])
 
 
 def teardown(keep=False):

--- a/tern/tools/fs_hash.sh
+++ b/tern/tools/fs_hash.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2018-2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 #
 # Given a file path, create a list of file stats and their sha256sums
@@ -14,11 +14,11 @@
 # Check that all commands to collect metadata exist on the
 # system otherwise exit.
 
-command -v find || { echo "'find' not found on system." >&2 ; exit 1; }
-command -v sha256sum || { echo "'sha256sum' not found on system." >&2 ; exit 1; }
-command -v getfattr || { echo "'getfattr' not found on system." >&2 ; exit 1; }
+command -v find > /dev/null || { echo "'find' not found on system." >&2 ; exit 1; }
+command -v sha256sum > /dev/null || { echo "'sha256sum' not found on system." >&2 ; exit 1; }
+command -v getfattr > /dev/null || { echo "'getfattr' not found on system." >&2 ; exit 1; }
 
 cwd=`pwd`
 cd $1
-find -type f ! -size 0 -printf "%M|%U|%G|%s|%n|" -exec sha256sum {} \; -exec getfattr -d -m - {} \;
+find -type f -printf "%M|%U|%G|%s|%n|  " -exec sha256sum {} \; -exec getfattr -d -m - {} \;
 cd $cwd

--- a/tern/utils/rootfs.py
+++ b/tern/utils/rootfs.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2020 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 """
@@ -21,7 +21,7 @@ remove = ['rm', '-rf']
 
 # tar commands
 check_tar = ['tar', '-tf']
-extract_tar = ['tar', '-x', '--exclude=.wh.*', '-f']
+extract_tar = ['tar', '-x', '-f']
 
 # mount commands
 mount = ['mount', '-o', 'bind']
@@ -302,8 +302,6 @@ def calc_fs_hash(fs_path):
     try:
         fs_hash_path = pkg_resources.resource_filename(
             "tern", "tools/fs_hash.sh")
-        # required to run in a container natively on Windows
-        root_command(["chmod", "+x", fs_hash_path])
         hash_contents = root_command(
             [fs_hash_path], os.path.abspath(fs_path))
         file_name = hashlib.sha256(hash_contents).hexdigest()

--- a/tern/utils/rootfs.py
+++ b/tern/utils/rootfs.py
@@ -204,7 +204,7 @@ def prep_base_layer(base_layer_tar):
     return target_dir_path
 
 
-def mount_diff_layers(diff_layers_tar, driver=None):
+def mount_diff_layers(diff_layers_tar, driver='overlay2'):
     '''Using overlayfs, mount all the layer tarballs'''
     # make a list of directory paths to give to lowerdir
     lower_dir_paths = []
@@ -218,7 +218,7 @@ def mount_diff_layers(diff_layers_tar, driver=None):
            ',workdir=' + workdir_path
     if driver == 'fuse':
         root_command(fuse_mount, args, merge_dir_path)
-    else:
+    if driver == 'overlay2':
         root_command(union_mount, args, merge_dir_path)
     return merge_dir_path
 

--- a/tests/test_class_file_data.py
+++ b/tests/test_class_file_data.py
@@ -195,6 +195,13 @@ class TestClassFileData(unittest.TestCase):
         self.assertEqual(
             file1.origins.origins[0].notices[0].message, 'something happened')
 
+    def testSetWhiteout(self):
+        whiteout = FileData('.wh.os-release', 'usr/lib/.wh.os-release')
+        whiteout.set_whiteout()
+        self.assertTrue(whiteout.is_whiteout)
+        self.afile.set_whiteout()
+        self.assertFalse(self.afile.is_whiteout)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #1086

This PR brings in changes required to enable Tern to run in an
unprivileged container. This allows us to run Tern on platforms
that do not allow containers with CAP_SYS_ADMIN privileges.

The major change is to include a method of applying the diff
filesystem layers using bulk copying of the files and directories
into the merge directory, rather than using a storage driver like
overlay2 or fuse. However, in order to do this, we also need to
manually handle whiteout files. Commits 1 and 2 handle
detection and use of whiteout files. Commit 1 reverts a change
that excludes whiteout files during the tarball extraction and Commit
2 handles checking and tracking of whiteout files in each image
layer.

Commit 3 removes any unnecessary mounting of inodes, thus
removing the need to run any kind of bind mounts. Commit 4
introduces the manual application of layers to replace overlay
mounting. Commit 5 handles applying layers when there is a
cache hit. Finally Commit 6 modifies the Dockerfiles to no
longer run tern with an external driver. The option is still available
via the `--driver fuse` option, hence not breaking operation for
downstream users. At the same time, the docker_run.sh script
will use the default driver rather than the fuse driver.

Signed-off-by: Nisha K <nishak@vmware.com>