### PR TITLE
Use Skopeo to pull container images

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Tern gives you a deeper understanding of your container's bill of materials so y
 
 ![Tern quick demo](/docs/img/tern_demo_fast.gif)
 
-
 # Getting Started<a name="getting-started"/>
 
 ## GitHub Action<a name="github-action"/>
@@ -70,13 +69,16 @@ If you have a Linux OS you will need a distro with a kernel version >= 4.0 (Ubun
 - Python 3.6 or newer (sudo apt-get install python3.6(3.7) or sudo dnf install python36(37))
 - Pip (sudo apt-get install python3-pip).
 - jq (sudo apt-get install jq or sudo dnf install jq)
+- skopeo (See [here](https://github.com/containers/skopeo/blob/main/install.md) for installation instructions or building from source)
 
-Some distro versions have all of these except `attr` and/or `jq` preinstalled but both are common utilities and are available via the package manager.
+Some distro versions have all of these except `attr`, `jq`, and/or `skopeo` preinstalled. `attr` and `jq` are common utilities and are available via the package manager. `skopeo` has only recently been packaged for common Linux distros. If you don't see your distro in the list, your best bet is building from source, which is reasonably straightforward if you have Go installed.
 
-For Docker containers
+For analyzing Dockerfiles and to use the "lock" function
 - Docker CE (Installation instructions can be found here: https://docs.docker.com/engine/installation/#server)
 
-Make sure the docker daemon is running.
+*NOTE:* We do not provide advice on the usage of [Docker Desktop](https://www.docker.com/blog/updating-product-subscriptions/)
+
+Once installed, make sure the docker daemon is running.
 
 Create a python3 virtual environment:
 ```
@@ -103,7 +105,7 @@ $ tern report -o output.txt -i debian:buster
 ```
 
 ## Getting Started with Docker<a name="getting-started-with-docker">
-Docker is the most widely used tool to build and run containers. If you already have Docker installed, you can run Tern by building a container with the Dockerfile provided and the `docker_run.sh` script:
+Docker is the most widely used tool to build and run containers. If you already have Docker installed, you can run Tern by building a container with the Dockerfile provided.
 
 Clone this repository:
 ```
@@ -132,7 +134,13 @@ $ docker build -f ci/Dockerfile -t ternd .
 +ENTRYPOINT ["tern", "-q"]
 ```
 
-Run the script `docker_run.sh`. You may need to use sudo. In the below command `debian` is the docker hub container image name  and `buster` is the tag that identifies the version we are interested in analyzing.
+Run the ternd container image
+
+```
+$ docker run --rm ternd report -i debian:buster
+```
+
+If you are using this container to analyze Dockerfiles and to use the "lock" feature, then you must volume mount the docker socket. We have a convenience script which will do that for you. 
 
 ```
 $ ./docker_run.sh ternd "report -i debian:buster" > output.txt
@@ -143,14 +151,15 @@ To produce a json report run
 $ ./docker_run.sh ternd "report -f json -i debian:buster"
 ```
 
-What the `docker_run.sh` script does is run the built container.
-
 Tern is not distributed as Docker images yet. This is coming soon. Watch the [Project Status](#project-status) for updates.
 
 **WARNING**: If using the `--driver fuse` or `--driver overlay2` storage driver options, then the docker image needs to run as privileged.
+
 ```
-docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock ternd "--driver fuse report -i debian:buster"
+docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock ternd --driver fuse report -i debian:buster
 ```
+
+You can make this change to the `docker_run.sh` script to make it easier.
 
 ## Getting Started with Vagrant<a name="getting-started-with-vagrant">
 Vagrant is a tool to setup an isolated virtual software development environment. If you are using Windows or Mac OSes and want to run Tern from the command line (not in a Docker container) this is the best way to get started as Tern does not run natively in a Mac OS or Windows environment at this time.

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -24,6 +24,7 @@ RUN echo "deb http://deb.debian.org/debian bullseye main" > /etc/apt/sources.lis
     fuse3/bullseye \
     git \
     jq \
+    skopeo \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /install /usr/local

--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -48,8 +48,12 @@ test_suite = {
     # tern/classes
     re.compile('tern/classes/command.py'):
     ['python tests/test_class_command.py'],
+    re.compile('tern/classes/oci_image.py'):
+    ['tern report -i photon:3.0',
+     'python tests/test_class_oci_image.py'],
     re.compile('tern/classes/docker_image.py'):
-    ['tern report -i photon:3.0'],
+    ['tern report -d samples/alpine_python/Dockerfile',
+     'python tests/test_class_docker_image.py'],
     re.compile('tern/classes/file_data.py'):
     ['python tests/test_class_file_data.py'],
     re.compile('tern/classes/image.py'):
@@ -121,6 +125,8 @@ test_suite = {
         ['python tests/test_analyze_default_dockerfile_parse.py'],
     re.compile('tests/test_class_command.py'):
         ['python tests/test_class_command.py'],
+    re.compile('tests/test_class_oci_image.py'):
+        ['python tests/test_class_oci_image.py'],
     re.compile('tests/test_class_docker_image.py'):
         ['python tests/test_class_docker_image.py',
          'tern report -w photon.tar'],

--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 from git import Repo

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,6 +23,7 @@ RUN echo "deb http://deb.debian.org/debian bullseye main" > /etc/apt/sources.lis
     fuse3/bullseye \
     git \
     jq \
+    skopeo \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /install /usr/local

--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -70,8 +70,8 @@ def check_image_input(options):
             logger.critical(errors.incorrect_raw_option)
             sys.exit(1)
     # Check if the image string has the right format
-    if options.docker_image:
-        if not check_image_string(options.docker_image):
+    if options.image:
+        if not check_image_string(options.image):
             logger.critical(errors.incorrect_image_string_format)
             sys.exit(1)
 
@@ -108,9 +108,9 @@ def do_main(args):
                 drun.execute_dockerfile(args)
             else:
                 logger.critical("Currently --layer/-y can only be used with"
-                                " --docker-image/-i")
+                                " --image/-i")
                 sys.exit(1)
-        elif args.docker_image or args.raw_image:
+        elif args.image or args.raw_image:
             check_image_input(args)
             # If the checks are OK, execute for docker image
             crun.execute_image(args)
@@ -167,15 +167,13 @@ def main():
     parser_report.add_argument('-d', '--dockerfile', type=check_file_existence,
                                help="Dockerfile used to build the Docker"
                                " image")
-    parser_report.add_argument('-i', '--docker-image',
-                               help="Docker image that exists locally -"
-                               " image:tag"
-                               " The option can be used to pull docker"
-                               " images by digest as well -"
-                               " <repo>@<digest-type>:<digest>")
+    parser_report.add_argument('-i', '--image',
+                               help="A container image referred either by "
+                               " repo:tag or repo@digest-type:digest")
     parser_report.add_argument('-w', '--raw-image', metavar='FILE',
                                help="Raw container image that exists locally "
-                               "in the form of a tar archive.")
+                               "in the form of a tar archive. Only the output"
+                               "of 'docker save' is supported")
     parser_report.add_argument('-y', '--layer', metavar='LAYER_NUMBER',
                                const=1, action='store',
                                dest='load_until_layer',

--- a/tern/analyze/common.py
+++ b/tern/analyze/common.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2020 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 '''
@@ -18,7 +18,6 @@ from tern.classes.command import Command
 from tern.utils import cache
 from tern.utils import constants
 from tern.utils import general
-from tern.utils import rootfs
 from debian_inspector import debcon
 from debian_inspector import copyright as debut_copyright
 
@@ -152,7 +151,7 @@ def save_to_cache(image):
 
 def is_empty_layer(layer):
     '''Return True if the given image layer is empty'''
-    cwd = rootfs.get_untar_dir(layer.tar_file)
+    cwd = layer.get_untar_dir()
     if len(os.listdir(cwd)) == 0:
         return True
     return False

--- a/tern/analyze/default/container/multi_layer.py
+++ b/tern/analyze/default/container/multi_layer.py
@@ -41,7 +41,7 @@ def apply_layers(image_obj, top_layer):
     """Apply image diff layers without using a kernel snapshot driver"""
     # All merging happens in the merge directory
     target = os.path.join(rootfs.get_working_dir(), constants.mergedir)
-    layer_dir = rootfs.get_untar_dir(image_obj.layers[top_layer].tar_file)
+    layer_dir = image_obj.layers[top_layer].get_untar_dir()
     layer_contents = layer_dir + '/*'
     # Account for whiteout files
     for fd in image_obj.layers[top_layer].files:

--- a/tern/analyze/default/container/multi_layer.py
+++ b/tern/analyze/default/container/multi_layer.py
@@ -30,10 +30,10 @@ logger = logging.getLogger(constants.logger_name)
 def mount_overlay_fs(image_obj, top_layer, driver):
     '''Given the image object and the top most layer, mount all the layers
     until the top layer using overlayfs'''
-    tar_layers = []
+    layer_paths = []
     for index in range(0, top_layer + 1):
-        tar_layers.append(image_obj.layers[index].tar_file)
-    target = rootfs.mount_diff_layers(tar_layers, driver)
+        layer_paths.append(image_obj.layers[index].get_untar_dir())
+    target = rootfs.mount_diff_layers(layer_paths, driver)
     return target
 
 

--- a/tern/analyze/default/container/run.py
+++ b/tern/analyze/default/container/run.py
@@ -14,7 +14,7 @@ from tern.utils import rootfs
 from tern.report import report
 from tern.report import formats
 from tern import prep
-from tern.load import docker_api
+from tern.load import skopeo
 from tern.analyze import common
 from tern.analyze.default.container import image as cimage
 
@@ -27,28 +27,20 @@ def extract_image(args):
     """The image can either be downloaded from a container registry or provided
     as an image tarball. Extract the image into a working directory accordingly
     Return an image name and tag and an image digest if it exists"""
-    if args.docker_image:
-        # extract the docker image
-        image_attrs = docker_api.dump_docker_image(args.docker_image)
-        if image_attrs:
-            # repo name and digest is preferred, but if that doesn't exist
-            # the repo name and tag will do. If neither exist use repo Id.
-            if image_attrs['Id']:
-                image_string = image_attrs['Id']
-            if image_attrs['RepoTags']:
-                image_string = image_attrs['RepoTags'][0]
-            if image_attrs['RepoDigests']:
-                image_string = image_attrs['RepoDigests'][0]
-            return image_string
-        logger.critical("Cannot extract Docker image")
+    if args.image:
+        # download the image
+        result = skopeo.pull_image(args.image)
+        if result:
+            return 'oci', args.image
+        logger.critical("Cannot download Container image: \"%s\"", args.image)
     if args.raw_image:
         # for now we assume that the raw image tarball is always
         # the product of "docker save", hence it will be in
         # the docker style layout
         if rootfs.extract_tarfile(args.raw_image, rootfs.get_working_dir()):
-            return args.raw_image
-        logger.critical("Cannot extract raw image")
-    return None
+            return 'docker', args.raw_image
+        logger.critical("Cannot extract raw Docker image")
+    return None, None
 
 
 def setup(image_obj):
@@ -72,11 +64,11 @@ def teardown(image_obj):
 def execute_image(args):
     """Execution path for container images"""
     logger.debug('Starting analysis...')
-    image_string = extract_image(args)
+    image_type, image_string = extract_image(args)
     # If the image has been extracted, load the metadata
-    if image_string:
+    if image_type and image_string:
         full_image = cimage.load_full_image(
-            image_string, args.load_until_layer)
+            image_string, image_type, args.load_until_layer)
         # check if the image was loaded successfully
         if full_image.origins.is_empty():
             # Add an image origin here

--- a/tern/analyze/default/container/single_layer.py
+++ b/tern/analyze/default/container/single_layer.py
@@ -62,7 +62,7 @@ def find_os_release(host_path):
 def get_os_release(base_layer):
     """Assuming that the layer tarball is untarred are ready to be inspected,
     get the OS information from the os-release file"""
-    return find_os_release(rootfs.get_untar_dir(base_layer.tar_file))
+    return find_os_release(base_layer.get_untar_dir())
 
 
 def get_os_style(image_layer, binary):

--- a/tern/analyze/default/debug/run.py
+++ b/tern/analyze/default/debug/run.py
@@ -26,10 +26,10 @@ from tern.analyze.default.container import single_layer
 from tern.analyze.default.container import multi_layer
 
 
-def check_image_obj(image_string):
+def check_image_obj(image_string, image_type):
     """Return the image object and if it was loaded successfully"""
     if image_string:
-        full_image = cimage.load_full_image(image_string)
+        full_image = cimage.load_full_image(image_string, image_type)
         if full_image.origins.is_empty():
             return full_image, True
         print("Something went wrong in loading the image")
@@ -190,9 +190,9 @@ def recover():
 
 def execute_debug(args):
     """Debug container images"""
-    if args.docker_image:
-        image_string = run.extract_image(args)
-        full_image, success = check_image_obj(image_string)
+    if args.image:
+        image_type, image_string = run.extract_image(args)
+        full_image, success = check_image_obj(image_string, image_type)
         if success:
             if args.keys:
                 # we have an image to mount and some scripts to invoke

--- a/tern/analyze/default/default_common.py
+++ b/tern/analyze/default/default_common.py
@@ -44,7 +44,7 @@ def find_shell(fspath):
 def get_shell(layer):
     '''Find the shell if any on the layer filesystem. Assume that the layer
     has already been unpacked. If there is no shell, return an empty string'''
-    cwd = rootfs.get_untar_dir(layer.tar_file)
+    cwd = layer.get_untar_dir()
     return find_shell(cwd)
 
 
@@ -54,7 +54,7 @@ def get_base_bin(first_layer):
     image and looking for known binaries there. Assume that the layer has
     already been unpacked with the filesystem'''
     binary = ''
-    cwd = rootfs.get_untar_dir(first_layer.tar_file)
+    cwd = first_layer.get_untar_dir()
     for key, value in command_lib.command_lib['base'].items():
         for path in value['path']:
             if os.path.exists(os.path.join(cwd, path)):

--- a/tern/analyze/default/dockerfile/run.py
+++ b/tern/analyze/default/dockerfile/run.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 """
@@ -123,7 +123,7 @@ def full_image_analysis(dfile, options):
     """This subroutine is executed when a Dockerfile is successfully built"""
     image_list = []
     # attempt to load the built image metadata
-    full_image = cimage.load_full_image(dfile)
+    full_image = cimage.load_full_image(dfile, image_type='docker')
     if full_image.origins.is_empty():
         # Add an image origin here
         full_image.origins.add_notice_origin(

--- a/tern/analyze/passthrough.py
+++ b/tern/analyze/passthrough.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 """
@@ -9,7 +9,6 @@ Use an external tool to analyze a container image
 
 
 import logging
-import os
 import shutil
 from stevedore import driver
 from stevedore.exception import NoMatches
@@ -46,18 +45,7 @@ def get_filesystem_command(layer_obj, command):
     # is the last token in the command. So the most straightforward way
     # to perform this operation is to append the target directory
     cmd_list = get_exec_command(command)
-    cmd_list.append(rootfs.get_untar_dir(layer_obj.tar_file))
-    return cmd_list
-
-
-def get_file_command(layer_tar_file, layer_file, command):
-    '''Given an ImageLayer object's tar_file property and a FileData object
-    from that layer, along with the command, return the command in list form
-    with the target file appended at the end'''
-    cmd_list = get_exec_command(command)
-    file_path = os.path.join(
-        rootfs.get_untar_dir(layer_tar_file), layer_file.path)
-    cmd_list.append(file_path)
+    cmd_list.append(layer_obj.get_untar_dir())
     return cmd_list
 
 

--- a/tern/classes/oci_image.py
+++ b/tern/classes/oci_image.py
@@ -1,32 +1,24 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2021 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 import json
-import os
 import subprocess  # nosec
 
 from tern.utils import rootfs
 from tern.utils import general
-from tern.utils.constants import manifest_file
-
-from tern.classes.image_layer import ImageLayer
 from tern.classes.image import Image
+from tern.utils.constants import manifest_file
+from tern.classes.image_layer import ImageLayer
 
 
-class DockerImage(Image):
-    '''A representation of an image created by Docker
-    See image.py for super class's attributes
-    Docker Image specific attributes:
-        repotags: the list of repotags associated with this image
-        history: a list of commands used to create the filesystem layers
-        to_dict: return a dict representation of the object
-    '''
-    def __init__(self, repotag=None, repo_digest=None):
-        '''Initialize using repotag'''
+class OCIImage(Image):
+    """A representation of an OCI compatible image that exists on disk"""
+    def __init__(self, repotag=None):
         super().__init__(repotag)
-        self.__repotags = []
+        # In case the OCI image corresponds with an image built by Docker
+        # we also include the history
         self.__history = None
         if self.repotag is None:
             raise NameError("Image object initialized with no repotag")
@@ -37,29 +29,17 @@ class DockerImage(Image):
         self._tag = repo_dict.get('tag')
         self.set_checksum(
             repo_dict.get('digest_type'), repo_dict.get('digest'))
-        if not self.checksum and general.check_tar(repotag) is False:
-            # see if we can set it via the repo_digest string
-            if repo_digest and ':' in repo_digest:
-                repo_digest_list = repo_digest.split(':')
-                self.set_checksum(repo_digest_list[0], repo_digest_list[1])
-
-    @property
-    def repotags(self):
-        return self.__repotags
 
     @property
     def history(self):
         return self.__history
 
     def to_dict(self, template=None):
-        '''Return a dictionary representation of the Docker image'''
         # this should take care of 'origins' and 'layers'
-        di_dict = super().to_dict(template)
-        return di_dict
+        oci_dict = super().to_dict(template)
+        return oci_dict
 
     def get_image_manifest(self):
-        '''Assuming that there is a temp folder with a manifest.json of
-        an image inside, get a dict of the manifest.json file'''
         temp_path = rootfs.get_working_dir()
         with general.pushd(temp_path):
             with open(manifest_file, encoding='utf-8') as f:
@@ -67,31 +47,16 @@ class DockerImage(Image):
         return json_obj
 
     def get_image_layers(self, manifest):
-        '''Given the manifest, return the layers'''
         layers = []
-        for layer in manifest[0].get('Layers'):
-            layers.append(layer)
+        for layer in manifest.get('layers'):
+            layers.append(layer.get("digest").split(":")[1])
         return layers
 
     def get_image_config_file(self, manifest):
-        '''Given the manifest, return the config file'''
-        return manifest[0].get('Config')
-
-    def get_image_repotags(self, manifest):
-        '''Given the manifest, return the list of image tag strings'''
-        return manifest[0].get('RepoTags')
-
-    def get_layer_sha(self, layer_path):
-        '''Docker's layers are file paths starting with the ID.
-        Get just the sha'''
-        return os.path.dirname(layer_path)
+        return manifest.get('config').get("digest").split(":")[1]
 
     def get_image_config(self, manifest):
-        '''Assuming there now exists a working directory where the image
-        metadata exists, return the image config'''
         config_file = self.get_image_config_file(manifest)
-        # assuming that the config file path is in the same root path as the
-        # manifest file
         temp_path = rootfs.get_working_dir()
         with general.pushd(temp_path):
             with open(config_file, encoding='utf-8') as f:
@@ -99,13 +64,11 @@ class DockerImage(Image):
         return json_obj
 
     def get_image_history(self, config):
-        '''If the config has the image history return it. Else return None'''
         if 'history' in config.keys():
             return config['history']
         return None
 
     def get_diff_ids(self, config):
-        '''Given the image config, return the filesystem diff ids'''
         diff_ids = []
         for item in config['rootfs']['diff_ids']:
             diff_ids.append(item.split(':').pop())
@@ -117,9 +80,6 @@ class DockerImage(Image):
         return config['rootfs']['diff_ids'][0].split(':')[0]
 
     def set_layer_created_by(self):
-        '''Docker image history configuration consists of a list of commands
-        and indication of whether the command created a filesystem or not.
-        Set the created_by for each layer in the image'''
         # the history is ordered according to the order of the layers
         # so the first non-empty history corresponds with the first layer
         index = 0
@@ -130,36 +90,35 @@ class DockerImage(Image):
                 else:
                     self._layers[index].created_by = ''
                 index = index + 1
-                if index is self.load_until_layer:
-                    break
 
     def load_image(self, load_until_layer=0):
-        """Load metadata from an extracted docker image. This assumes the
-        image has already been downloaded and extracted into the working
-        directory"""
         if load_until_layer > 0:
             self._load_until_layer = load_until_layer
-        # else defaults to 0 - handles negative load_until_layer
         try:
             self._manifest = self.get_image_manifest()
-            self.__repotags = self.get_image_repotags(self._manifest)
             self._config = self.get_image_config(self._manifest)
             self.__history = self.get_image_history(self._config)
             layer_paths = self.get_image_layers(self._manifest)
             layer_diffs = self.get_diff_ids(self._config)
-            checksum_type = self.get_diff_checksum_type(self._config)
+            # if the digest isn't in the repotag, get it from the config
+            if not self.checksum:
+                repo_dict = general.parse_image_string(
+                    self._config.get("config").get("Image"))
+                self.set_checksum(repo_dict.get("digest_type"),
+                                  repo_dict.get("digest"))
+            layer_checksum_type = self.get_diff_checksum_type(self._config)
             layer_count = 1
             while layer_diffs and layer_paths:
                 layer = ImageLayer(layer_diffs.pop(0), layer_paths.pop(0))
-                # Only load metadata for the layers we need to report on
-                # according to the --layers command line option
-                # If  --layers option is not present, load all the layers
                 if (self.load_until_layer >= layer_count
                         or self.load_until_layer == 0):
-                    layer.set_checksum(checksum_type, layer.diff_id)
-                    layer.image_layout = "docker"
-                    layer.gen_fs_hash()
+                    layer.set_checksum(layer_checksum_type, layer.diff_id)
+                    layer.image_layout = "oci"
+                    # take care to set the layer index as it will be used
+                    # to create the directory where the layer contents will
+                    # be untarred
                     layer.layer_index = layer_count
+                    layer.gen_fs_hash()
                     self._layers.append(layer)
                 layer_count = layer_count + 1
             self._total_layers = layer_count - 1

--- a/tern/formats/html/generator.py
+++ b/tern/formats/html/generator.py
@@ -148,12 +148,20 @@ def manifest_handler(list_obj, indent):
 
 
 def layers_handler(list_obj, indent):
-    '''Write html code for the origins list in the report
+    '''Write html code for the layers list in the report
     with tar_file hash as title'''
     html_string = '  '*indent + '<ul class ="nested"> \n'
     for lo in list_obj:
+        # check whether the item is a dictionary that contains the "tar_file"
+        # property or not
+        if "tar_file" in lo:
+            title = str(lo["tar_file"][:10])
+        elif "digest" in lo:
+            title = str(lo["digest"][:10])
+        else:
+            title = list_obj.index(lo)
         html_string = html_string + '  '*indent + '<li><span class="caret">' \
-            + str(lo["tar_file"][:10]) + ' : ' + '</span> \n '
+            + title + ' : ' + '</span> \n '
         html_string = html_string + dict_handler(lo, indent+1)
         html_string = html_string + '  '*indent + '</li> \n'
     html_string = html_string + '  '*indent + '</ul> \n'

--- a/tern/load/skopeo.py
+++ b/tern/load/skopeo.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Interactions with remote container images using skopeo
+"""
+
+import logging
+import sys
+import shutil
+
+from tern.utils import constants
+from tern.utils import rootfs
+
+# global logger
+logger = logging.getLogger(constants.logger_name)
+
+
+def check_skopeo_setup():
+    """Check if the skopeo tool is installed"""
+    if not shutil.which('skopeo'):
+        logger.critical('Skopeo is not installed')
+        logger.critical('Exiting...')
+        sys.exit(1)
+
+
+def pull_image(image_tag_string):
+    """Use skopeo to pull a remote image into the working directory"""
+    # Check if skopeo is set up
+    check_skopeo_setup()
+    # we will assume the docker transport for now
+    remote = f'docker://{image_tag_string}'
+    local = f'dir:{rootfs.get_working_dir()}'
+    logger.debug("Attempting to pull image \"%s\"", image_tag_string)
+    result, error = rootfs.shell_command(
+        False, ['skopeo', 'copy', remote, local])
+    if error:
+        logger.error("Error when downloading image: \"%s\"", error)
+        return None
+    return result

--- a/tern/prep.py
+++ b/tern/prep.py
@@ -54,7 +54,7 @@ def teardown(keep=False):
 def clean_image_tars(image_obj):
     """Given an image object, clean up all the image layer contents"""
     for layer in image_obj.layers:
-        fspath = rootfs.get_untar_dir(layer.tar_file)
+        fspath = layer.get_untar_dir()
         if os.path.exists(fspath):
             rootfs.root_command(rootfs.remove, fspath)
 

--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -30,7 +30,7 @@ def write_report(report, args):
 def clean_image_tars(image_obj):
     '''Clean up untar directories'''
     for layer in image_obj.layers:
-        fspath = rootfs.get_untar_dir(layer.tar_file)
+        fspath = layer.get_untar_dir()
         if os.path.exists(fspath):
             rootfs.root_command(rootfs.remove, fspath)
 

--- a/tern/utils/rootfs.py
+++ b/tern/utils/rootfs.py
@@ -121,17 +121,6 @@ def get_working_dir():
     return os.path.join(working_dir, constants.temp_folder)
 
 
-def get_untar_dir(layer_tarfile):
-    '''get the directory to untar the layer tar file'''
-    return os.path.join(get_working_dir(), os.path.dirname(
-        layer_tarfile), constants.untar_dir)
-
-
-def get_layer_tar_path(layer_tarfile):
-    '''get the full path of the layer tar file'''
-    return os.path.join(get_working_dir(), layer_tarfile)
-
-
 def set_up():
     '''Create required directories'''
     op_dir = get_working_dir()
@@ -204,14 +193,12 @@ def prep_base_layer(base_layer_tar):
     return target_dir_path
 
 
-def mount_diff_layers(diff_layers_tar, driver='overlay2'):
-    '''Using overlayfs, mount all the layer tarballs'''
+def mount_diff_layers(diff_layer_paths, driver='overlay2'):
+    """Given a list of diff filesystem layer paths, mount all the layers
+    using an overlay driver. Supported drivers are 'fuse' and 'overlay2'"""
     # make a list of directory paths to give to lowerdir
-    lower_dir_paths = []
-    for layer_tar in diff_layers_tar:
-        lower_dir_paths.append(get_untar_dir(layer_tar))
-    upper_dir = lower_dir_paths.pop()
-    lower_dir = ':'.join(list(reversed(lower_dir_paths)))
+    upper_dir = diff_layer_paths.pop()
+    lower_dir = ':'.join(list(reversed(diff_layer_paths)))
     merge_dir_path = os.path.join(get_working_dir(), constants.mergedir)
     workdir_path = os.path.join(get_working_dir(), constants.workdir)
     args = 'lowerdir=' + lower_dir + ',upperdir=' + upper_dir + \

--- a/tests/test_class_image_layer.py
+++ b/tests/test_class_image_layer.py
@@ -4,10 +4,12 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import unittest
+import os
 
 from tern.classes.image_layer import ImageLayer
 from tern.classes.package import Package
 from tern.classes.file_data import FileData
+from tern.utils import rootfs
 from test_fixtures import TestTemplate1
 from test_fixtures import TestTemplate2
 
@@ -16,6 +18,7 @@ class TestClassImageLayer(unittest.TestCase):
 
     def setUp(self):
         self.layer = ImageLayer('123abc', 'path/to/tar')
+        rootfs.set_working_dir()
 
     def tearDown(self):
         del self.layer
@@ -145,6 +148,23 @@ class TestClassImageLayer(unittest.TestCase):
             self.layer.extension_info.get("header", None), set)
         header = self.layer.extension_info.get("header").pop()
         self.assertEqual(header, "Test Header")
+
+    def testGetUntarDir(self):
+        self.layer.image_layout = "oci"
+        self.assertEqual(self.layer.image_layout, "oci")
+        self.layer.image_layout = "docker"
+        self.assertEqual(self.layer.image_layout, "docker")
+        self.layer.image_layout = ""
+        self.assertEqual(self.layer.image_layout, "oci")
+        self.layer.layer_index = 1
+        self.assertEqual(self.layer.layer_index, "1")
+        expected_path = os.path.join(rootfs.get_working_dir(),
+                                     '1/contents')
+        self.assertEqual(self.layer.get_untar_dir(), expected_path)
+        self.layer.image_layout = "docker"
+        expected_path = os.path.join(rootfs.get_working_dir(),
+                                     'path/to/contents')
+        self.assertEqual(self.layer.get_untar_dir(), expected_path)
 
 
 if __name__ == '__main__':

--- a/tests/test_class_oci_image.py
+++ b/tests/test_class_oci_image.py
@@ -1,18 +1,18 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2020 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 import unittest
 
-from tern.load.docker_api import dump_docker_image
-from tern.classes.docker_image import DockerImage
+from tern.load import skopeo
+from tern.classes.oci_image import OCIImage
 from tern.utils import rootfs
 from test_fixtures import create_working_dir
 from test_fixtures import remove_working_dir
 
 
-class TestClassDockerImage(unittest.TestCase):
+class TestClassOCIImage(unittest.TestCase):
 
     def setUp(self):
         '''Using a specific image here. If this test fails due to the image
@@ -21,10 +21,10 @@ class TestClassDockerImage(unittest.TestCase):
         create_working_dir()
         rootfs.set_working_dir()
         # this should check if the docker image extraction is successful
-        dump_docker_image('vmware/tern@sha256:20b32a9a20752aa1ad7582c667704f'
+        skopeo.pull_image('vmware/tern@sha256:20b32a9a20752aa1ad7582c667704f'
                           'da9f004cc4bfd8601fac7f2656c7567bb4')
-        self.image = DockerImage('vmware/tern@sha256:20b32a9a20752aa1ad7582c6'
-                                 '67704fda9f004cc4bfd8601fac7f2656c7567bb4')
+        self.image = OCIImage('vmware/tern@sha256:20b32a9a20752aa1ad7582c6'
+                              '67704fda9f004cc4bfd8601fac7f2656c7567bb4')
         # constants for this image
         self.layer = ('c1c3a87012e7ff5791b31e94515b661'
                       'cdf06f6d5dc2f9a6245eda8774d257a13')
@@ -67,16 +67,15 @@ class TestClassDockerImage(unittest.TestCase):
                                              '7704fda9f004cc4bfd8601fac7'
                                              'f2656c7567bb4')
         self.assertFalse(self.image.manifest)
-        self.assertFalse(self.image.repotags)
         self.assertFalse(self.image.config)
         self.assertFalse(self.image.layers)
         self.assertFalse(self.image.history)
         # test instantiating with a tag
-        d = DockerImage('vmware/tern:testimage')
-        self.assertEqual(d.name, 'vmware/tern')
-        self.assertEqual(d.tag, 'testimage')
-        self.assertFalse(d.checksum_type)
-        self.assertFalse(d.checksum)
+        o = OCIImage('vmware/tern:testimage')
+        self.assertEqual(o.name, 'vmware/tern')
+        self.assertEqual(o.tag, 'testimage')
+        self.assertFalse(o.checksum_type)
+        self.assertFalse(o.checksum)
 
     def testLoadImage(self):
         self.image.load_image()
@@ -94,7 +93,6 @@ class TestClassDockerImage(unittest.TestCase):
     def testLayerFiles(self):
         self.image.load_image()
         self.assertFalse(self.image.layers[0].files)
-        print(self.image.layers[0].image_layout)
         self.image.layers[0].add_files()
         for file in self.image.layers[0].files:
             self.assertTrue(

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -21,7 +21,7 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
-  config.vm.box = "generic/ubuntu1804"
+  config.vm.box = "generic/ubuntu2004"
   config.vm.provision :shell, path: "bootstrap.sh"
 
   config.vm.synced_folder '.', '/vagrant', disabled: true

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2018-2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 # Update the Ubuntu repositories
@@ -10,7 +10,14 @@ sudo apt-get update
 sudo apt-get -y upgrade
 
 # Python3 versions and system dependencies
-sudo apt-get install -y python3 python3-pip python3-venv attr
+sudo apt-get install -y python3 python3-pip python3-venv attr jq
+
+# Install skopeo for Ubuntu 20.04
+echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/Release.key | sudo apt-key add -
+sudo apt-get update
+sudo apt-get -y upgrade
+sudo apt-get -y install skopeo
 
 # Install Docker
 sudo apt-get install -y docker.io


### PR DESCRIPTION
This PR enables the use of Skopeo to pull container images.
Skopeo uses the OCI schema version 2 to fetch container images.
It lays out the images on disk differently than Docker after a pull.
In order to enable analysis of containers pulled in this way, this PR
introduces the OCIImage class which reflects the expected layout.

In order to deal with the different expected directory structures, commit 1
moves a commonly used function in rootfs.py, get_untar_dir, into the
ImageLayer class, and creates a new property called 'image_layout'.
In this way, container image layouts on disk can be dealt with based
on derived Image classes.

Commit 2 introduces the OCIImage class and changes to the
DockerImage class which makes use of the new ImageLayer property
and method. Commit 3 replaces all instances of get_untar_dir with the
ImageLayer instance's get_untar_dir method. Commit 4 connects all
the pieces from the command line option to the image extraction method.
Finally, commit 5 adds Skopeo to the list of requirements for Tern in the
documentation, Dockerfiles and the development environments.

Commit 6 deals with the different image dictionary layouts based on the
image layout in the html report specifically.

Note that the change to the Dockerfile that installs tern using pip has not
changed as this changeset is not included in any releases yet.

Fixes #948

Signed-off-by: Nisha K <nishak@vmware.com>