### PR TITLE
fix: unmount rootfs only for fuse and overlay2

### DIFF
--- a/tern/analyze/default/debug/run.py
+++ b/tern/analyze/default/debug/run.py
@@ -136,7 +136,8 @@ def execute_invoke(image_obj, args):
     # invoke commands in chroot
     invoke_script(args)
     # undo the mounts
-    rootfs.unmount_rootfs()
+    if args.driver in ('fuse', 'overlay2'):
+        rootfs.unmount_rootfs()
     # cleanup
     rootfs.clean_up()
     if not args.keep_wd:


### PR DESCRIPTION
In the debug run script, unmount the root filesystem only when
the driver used is 'fuse' or 'overlay2'. If using the default
bulk copy driver, this is not needed.

Signed-off-by: Nisha K <nishak@vmware.com>