### PR TITLE
Install skopeo in Dockerfile.scancode

### DIFF
--- a/docker/Dockerfile.scancode
+++ b/docker/Dockerfile.scancode
@@ -30,6 +30,7 @@ RUN echo "deb http://deb.debian.org/debian bullseye main" > /etc/apt/sources.lis
     git \
     jq \
     libgomp1 \
+    skopeo \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /install /usr/local


### PR DESCRIPTION
3a0ac50cd9090cc6426fa8bce070437db8ea3869 did not add the skopeo installation to `docker/Dockerfile.scancode`.

Therefore, when I build and run it, I get the following error:

```
$ docker build -f docker/Dockerfile.scancode -t ternd .
$ docker run --rm ternd report -i debian:buster
...
2022-01-12 05:06:09,577 - CRITICAL - skopeo - Skopeo is not installed
2022-01-12 05:06:09,577 - CRITICAL - skopeo - Exiting...
```

Fix it by install skopeo in `docker/Dockerfile.scancode`.