### PR TITLE
Fix CycloneDX report generation

### DIFF
--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -99,7 +99,8 @@ test_suite = {
         'tern report -f spdxtagvalue -i photon:3.0',
         'tern report -f spdxjson -i photon:3.0',
         'tern report -d samples/alpine_python/Dockerfile',
-        'tern report -f html -i photon:3.0'],
+        'tern report -f html -i photon:3.0',
+        'tern report -f cyclonedxjson -i photon:3.0'],
     # tern/formats/spdx
     re.compile('tern/formats/spdx'): [
         'tern report -f spdxtagvalue -i photon:3.0 -o spdx.spdx && ' \

--- a/tern/formats/cyclonedx/cyclonedxjson/image_helpers.py
+++ b/tern/formats/cyclonedx/cyclonedxjson/image_helpers.py
@@ -10,6 +10,8 @@ Helper functions for image level JSON CycloneDX document dictionaries
 
 from tern.formats.cyclonedx import cyclonedx_common
 from packageurl import PackageURL
+from tern.classes.oci_image import OCIImage
+from tern.classes.docker_image import DockerImage
 
 
 def get_image_dict(image_obj):
@@ -28,9 +30,11 @@ def get_image_dict(image_obj):
     purl = PackageURL('docker', None, image_dict['name'], image_dict['version'])
     image_dict['purl'] = str(purl)
 
-    if image_obj.repotags:
+    if isinstance(image_obj, DockerImage):
         for repotag in image_obj.repotags:
             image_dict['properties'].append(cyclonedx_common.get_property('tern:repotag', repotag))
+    elif isinstance(image_obj, OCIImage):
+        image_dict['properties'].append(cyclonedx_common.get_property('tern:repotag', image_obj.repotag))
 
     os_guess = cyclonedx_common.get_os_guess(image_obj)
     if os_guess:


### PR DESCRIPTION
Commit 0891287 introduced using the OCIImage class instead of
DockerImage for container image analysis. There is a difference in the
name and type of the variable that holds the repository tag ('repotags'
list for DockerImage vs 'repotag' string for OCIImage) which is causing
the CycloneDX format to break. This was not caught prior to the release
because there are no tests for the CycloneDX format in the ci test file.

This commit resolves the CycloneDX format bug by using the repository
tag variable name depending on image type and also adds an appropriate
test in the ci test file to try to avoid this issue in the future.

Lastly, we add 'undefined-variable' to the list of pylint and pyflakes
warnings to ignore as it was being incorrectly surfaced during
prospector runs.

Resolves #1097

Signed-off-by: Rose Judge <rjudge@vmware.com>