### PR TITLE
Fix scancode KeyError during license parsing

### DIFF
--- a/tern/extensions/scancode/executor.py
+++ b/tern/extensions/scancode/executor.py
@@ -81,14 +81,20 @@ def filter_pkg_license(declared_license):
     it will represent the license as a string or list of strings.
     Given a scancode declared_license field, extract and return a
     license string'''
-    if isinstance(declared_license, dict):
+    if isinstance(declared_license, dict) and len(declared_license) != 0:
         try:
             return declared_license['license']
         except KeyError:
-            # parse classifiers for PyPI licenses
-            # According to https://pypi.org/pypi?%3Aaction=list_classifiers
-            # we can always take the value after the last '::'
-            return declared_license['classifiers'][0].split('::')[-1].strip()
+            try:
+                return declared_license['License']
+            except KeyError:
+                try:
+                    # parse classifiers for PyPI licenses
+                    # According to pypi.org/pypi?%3Aaction=list_classifiers
+                    # we can always take the value after the last '::'
+                    return declared_license['classifiers'][0].split('::')[-1].strip()
+                except KeyError:
+                    return None
     if isinstance(declared_license, list):
         for i, lic in enumerate(declared_license):
             # Some license lists from Scancode have dictionary entries


### PR DESCRIPTION
When running Tern with Scancode, Tern tries to parse Scancode's
`declared_license` dictionary `license` key to determine the package
license. Sometimes this key is called `License` and sometimes the
`declared_license` dictionary is empty, however. In each of the
aforementioned cases Tern fails and throws a `KeyError`. This commit
fixes the error by checking for an empty dictionary before trying to
extract the license value and also checks for the `License` key in
addition to the `license` key.

Note that an issue[1] has been opened in the scancode repository asking
for clarity on whether the declared_license key should be `License` or
`license`. If any resolution comes from the scancode issue that has
been opened, it may make sense to revert parts of this change.

[1] https://github.com/nexB/scancode-toolkit/issues/2803

Resolves #1063

Signed-off-by: Rose Judge <rjudge@vmware.com>