### PR TITLE
Handle unknown/unsupported extension

### DIFF
--- a/tern/analyze/passthrough.py
+++ b/tern/analyze/passthrough.py
@@ -10,12 +10,14 @@ Use an external tool to analyze a container image
 
 import logging
 import shutil
+import sys
 from stevedore import driver
 from stevedore.exception import NoMatches
 
 from tern.classes.notice import Notice
 from tern.utils import constants
 from tern.utils import rootfs
+from tern.report import errors
 
 # global logger
 logger = logging.getLogger(constants.logger_name)
@@ -87,7 +89,9 @@ def run_extension(image_obj, ext_string, redo=False):
         )
         return mgr.driver.execute(image_obj, redo)
     except NoMatches:
-        return None
+        msg = errors.unrecognized_extension.format(ext=ext_string)
+        logger.critical(msg)
+        sys.exit(1)
 
 
 def run_extension_layer(image_layer, ext_string, redo=False):

--- a/tern/report/errors.py
+++ b/tern/report/errors.py
@@ -57,6 +57,7 @@ incorrect_raw_option = '''Expected path to tar archive.\n'''
 incorrect_image_string_format = '''Unsupported image string format.\n''' \
     '''Please provide string in image:tag or ''' \
     '''image@digest_type:digest format.\n'''
+unrecognized_extension = '''Extension "{ext}" not found. Exiting.'''
 
 # Dockerfile specific errors
 dockerfile_no_tag = '''The Dockerfile provided has no tag in the line ''' \


### PR DESCRIPTION
When providing the `-x` CLI option with an unknown extension, Tern
currently skips ahead to creating a report without any warning. This
commit makes changes to instead provide a warning message that the
provided extension cannot be found.

Resolves #827

Signed-off-by: Rose Judge <rjudge@vmware.com>