### PR TITLE
Enable packages installed by python3 -m pip

### DIFF
--- a/tern/analyze/default/command_lib/snippets.yml
+++ b/tern/analyze/default/command_lib/snippets.yml
@@ -118,6 +118,22 @@ pip3:
     - 'wheel'
   packages: 'pip3'
 
+python3:
+  install:
+    - 'install'
+  remove:
+    - 'uninstall'
+  ignore:
+    - 'freeze'
+    - 'list'
+    - 'download'
+    - 'show'
+    - 'check'
+    - 'config'
+    - 'hash'
+    - 'wheel'
+  packages: 'pip3'
+
 gem:
   install:
     - 'install'


### PR DESCRIPTION
In order to detect packages installed by pip but using the python3
module (-m), we add a snippet listing for "python3" that points
to the "pip3" package inventorying method

Fixes #1020

Signed-off-by: Nisha K <nishak@vmware.com>