### PR TITLE
Collect package information for SLES based images

### DIFF
--- a/tern/analyze/default/command_lib/base.yml
+++ b/tern/analyze/default/command_lib/base.yml
@@ -222,6 +222,7 @@ rpm:
     - 'RHEL'
   path:
     - 'usr/bin/rpm'
+    - 'var/lib/rpm'
   pkg_separators:
     - '-'
   pinning_separator: '-'


### PR DESCRIPTION
Tern currently looks for the rpm package manager utility in
`/usr/bin/rpm` in the base OS layer. However, for SLES base OSes this
utility is located in `/var/lib/rpm`. This commit adds the
`/var/lib/rpm` utility location to base.yml so Tern can find the package
manager and collect SLES package metadata for the reports.

Resolves #1122

Signed-off-by: Rose Judge <rjudge@vmware.com>