### PR TITLE
debug: Fix argument name and provide driver

### DIFF
--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -263,7 +263,7 @@ def main():
                               "mounting of the filesystem and device nodes, "
                               "recover the filesystem by undoing all the "
                               "mounts.")
-    parser_debug.add_argument('-i', '--docker-image',
+    parser_debug.add_argument('-i', '--image',
                               help="Docker image that exists locally -"
                               " image:tag"
                               " The option can be used to pull docker"

--- a/tern/analyze/default/debug/run.py
+++ b/tern/analyze/default/debug/run.py
@@ -175,17 +175,15 @@ def execute_step(image_obj, args):
         prep.clean_image_tars(image_obj)
 
 
-def recover():
+def recover(driver):
     """Undo all the mounts and clean up directories"""
-    try:
-        rootfs.unmount_rootfs()
-    except subprocess.CalledProcessError:
-        pass
-    # we nuke all the directories after mounting
+    if driver in ('overlay2', 'fuse'):
+        try:
+            rootfs.unmount_rootfs()
+        except subprocess.CalledProcessError:
+            pass
+    # nuking working directories
     rootfs.clean_up()
-    working_dir = rootfs.get_working_dir()
-    if os.path.exists(working_dir):
-        rootfs.root_command(rootfs.remove, working_dir)
 
 
 def execute_debug(args):
@@ -202,6 +200,6 @@ def execute_debug(args):
                 execute_step(full_image, args)
     elif args.recover:
         # we need to recover the filesystem
-        recover()
+        recover(args.driver)
     else:
         print("Debug mode: nothing to do")


### PR DESCRIPTION
The argument name for analyzing container images was changed from
`docker_image` to `image`, but the same change was not done for
the debug option. This commit fixes that oversight.

Further, the operation for recovery now takes account of the
driver that was used to analyze the container image layers. By
default, no unmount attempts will be made.

Some of the clean-up is delegated to the `teardown` operation,
common to all sub-commands.

Fixes #1123

Signed-off-by: Nisha K <nishak@vmware.com>