### PR TITLE
Allow explicitly turning off src-tls-verify

### DIFF
--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2021 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2022 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 """
@@ -181,6 +181,12 @@ def main():
     parser_report.add_argument('-i', '--image',
                                help="A container image referred either by "
                                " repo:tag or repo@digest-type:digest")
+    parser_report.add_argument('--no-tls', default=False,
+                               action='store_true',
+                               help="When fetching an image, DO NOT use HTTPS "
+                               " and DO NOT verify TLS certificates of the "
+                               "registry.\nThis is useful when using a local "
+                               "registry instance for debugging purposes.")
     parser_report.add_argument('-w', '--raw-image', metavar='FILE',
                                help="Raw container image that exists locally "
                                "in the form of a tar archive. Only the output"
@@ -269,6 +275,12 @@ def main():
                               " The option can be used to pull docker"
                               " images by digest as well -"
                               " <repo>@<digest-type>:<digest>")
+    parser_debug.add_argument('--no-tls', default=False,
+                              action='store_true',
+                              help="When fetching an image, DO NOT use HTTPS "
+                              " and DO NOT verify TLS certificates of the "
+                              "registry.\nThis is useful when using a local "
+                              "registry instance for debugging purposes.")
     parser_debug.add_argument('-w', '--raw-image', metavar='FILE',
                               help="Raw container image that exists locally "
                               "in the form of a tar archive.")

--- a/tern/analyze/default/container/run.py
+++ b/tern/analyze/default/container/run.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2019-2022 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 """
@@ -29,7 +29,7 @@ def extract_image(args):
     Return an image name and tag and an image digest if it exists"""
     if args.image:
         # download the image
-        result = skopeo.pull_image(args.image)
+        result = skopeo.pull_image(args.image, args.no_tls)
         if result:
             return 'oci', args.image
         logger.critical("Cannot download Container image: \"%s\"", args.image)

--- a/tern/load/skopeo.py
+++ b/tern/load/skopeo.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2021-2022 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 """
@@ -27,7 +27,7 @@ def check_skopeo_setup():
         sys.exit(1)
 
 
-def pull_image(image_tag_string):
+def pull_image(image_tag_string, no_tls=False):
     """Use skopeo to pull a remote image into the working directory"""
     # Check if skopeo is set up
     check_skopeo_setup()
@@ -35,8 +35,12 @@ def pull_image(image_tag_string):
     remote = f'docker://{image_tag_string}'
     local = f'dir:{rootfs.get_working_dir()}'
     logger.debug("Attempting to pull image \"%s\"", image_tag_string)
-    result, error = rootfs.shell_command(
-        False, ['skopeo', 'copy', remote, local])
+    if no_tls:
+        result, error = rootfs.shell_command(
+            False, ['skopeo', 'copy', '--src-tls-verify=false', remote, local])
+    else:
+        result, error = rootfs.shell_command(
+            False, ['skopeo', 'copy', remote, local])
     if error:
         logger.error("Error when downloading image: \"%s\"", error)
         return None


### PR DESCRIPTION
In situations where TLS is not enabled for a registry, users
may now turn off the option to check TLS certificates and use
HTTP rather than HTTPS to pull images using skopeo.

It is advised to not use this flag for untrusted registries and
only use it for registries hosted locally to testing or debugging.

This option is also added for the `debug` sub-command.

Fixes #1121 and #1087

Signed-off-by: Nisha K <nishak@vmware.com>