### PR TITLE
Collect extension and Tern metadata together

### DIFF
--- a/tern/analyze/default/container/image.py
+++ b/tern/analyze/default/container/image.py
@@ -65,17 +65,12 @@ def default_analyze(image_obj, options):
     master_list = []
     # Analyze the first layer and get prerequisites for the next layer
     prereqs = single_layer.analyze_first_layer(image_obj, master_list, options)
+    if options.extend:
+        # Run the extension that the user has chosen for the first layer
+        passthrough.run_extension_layer(image_obj.layers[0], options.extend,
+                                        options.redo)
     # Analyze the remaining layers if there are more
     if prereqs and len(image_obj.layers) > 1:
         multi_layer.analyze_subsequent_layers(
             image_obj, prereqs, master_list, options)
     return image_obj
-
-
-def analyze(image_obj, options):
-    """Either analyze a container image using the default method or pass
-    analysis to an external tool"""
-    if options.extend:
-        passthrough.run_extension(image_obj, options.extend, options.redo)
-    else:
-        default_analyze(image_obj, options)

--- a/tern/analyze/default/container/multi_layer.py
+++ b/tern/analyze/default/container/multi_layer.py
@@ -21,6 +21,7 @@ from tern.analyze.default import default_common as dcom
 from tern.analyze.default import core
 from tern.analyze.default.dockerfile import lock
 from tern.analyze.default.command_lib import command_lib
+from tern.analyze import passthrough
 
 
 # global logger
@@ -93,6 +94,11 @@ def fresh_analysis(image_obj, curr_layer, prereqs, options):
     target = prep_layers(image_obj, curr_layer, options.driver)
     # set this layer's host path
     prereqs.host_path = target
+    # If selected, collect extension metadata for the layer prior to using
+    # Tern's default analysis (order of collection is not important)
+    if options.extend:
+        passthrough.run_extension_layer(image_obj.layers[curr_layer],
+                                        options.extend, options.redo)
     # get commands that created the layer
     # for docker images this is retrieved from the image history
     command_list = dcom.get_commands_from_metadata(

--- a/tern/analyze/default/container/run.py
+++ b/tern/analyze/default/container/run.py
@@ -77,7 +77,7 @@ def execute_image(args):
             # Set up for analysis
             setup(full_image)
             # analyze image
-            cimage.analyze(full_image, args)
+            cimage.default_analyze(full_image, args)
             # report out
             report.report_out(args, full_image)
             # clean up

--- a/tern/analyze/default/dockerfile/run.py
+++ b/tern/analyze/default/dockerfile/run.py
@@ -71,7 +71,7 @@ def analyze_full_image(full_image, options):
     # set up for analysis
     crun.setup(full_image)
     # analyze image
-    cimage.analyze(full_image, options)
+    cimage.default_analyze(full_image, options)
     # clean up after analysis
     rootfs.clean_up()
     # we should now be able to set imported layers
@@ -108,7 +108,7 @@ def analyze_base_image(base_image, options):
     # set up for analysis
     crun.setup(base_image)
     # analyze image
-    cimage.analyze(base_image, options)
+    cimage.default_analyze(base_image, options)
     # clean up
     rootfs.clean_up()
     # save the base image to cache

--- a/tern/analyze/passthrough.py
+++ b/tern/analyze/passthrough.py
@@ -18,6 +18,8 @@ from tern.classes.notice import Notice
 from tern.utils import constants
 from tern.utils import rootfs
 from tern.report import errors
+from tern import prep
+
 
 # global logger
 logger = logging.getLogger(constants.logger_name)
@@ -78,22 +80,6 @@ def execute_and_pass(layer_obj, command, is_sudo=False):
         'utf-8') + '\n\n' + result.decode('utf-8')
 
 
-def run_extension(image_obj, ext_string, redo=False):
-    '''Depending on what tool the user has chosen to extend with, load that
-    extension and run it'''
-    try:
-        mgr = driver.DriverManager(
-            namespace='tern.extensions',
-            name=ext_string,
-            invoke_on_load=True,
-        )
-        return mgr.driver.execute(image_obj, redo)
-    except NoMatches:
-        msg = errors.unrecognized_extension.format(ext=ext_string)
-        logger.critical(msg)
-        sys.exit(1)
-
-
 def run_extension_layer(image_layer, ext_string, redo=False):
     '''Depending on what tool the user has chosen to extend with, load that
     extension and run it'''
@@ -105,4 +91,8 @@ def run_extension_layer(image_layer, ext_string, redo=False):
         )
         return mgr.driver.execute_layer(image_layer, redo)
     except NoMatches:
-        return None
+        msg = errors.unrecognized_extension.format(ext=ext_string)
+        logger.critical(msg)
+        rootfs.clean_up()
+        prep.clean_working_dir()
+        sys.exit(1)


### PR DESCRIPTION
Currently, if no cache file exists and you run Tern with an extension
(like Scancode), the output report will only include extension info in
the output report. This is because when an extension option is selected
on the command line, Tern only runs the extension capability and doesn't
collect any package metadata using the scripts in base.yml.
    
This commit changes Tern's extension behavior to run in parallel with
Tern's default metadata collection capability. Now, reports will include
extension information and package metadata collected from Tern scripts.
This change in behavior has been requested from several users as it is
more intuitive and in line with what users expect.

Some technical debt to simplify the `fresh_analysis` function is also
cleaned up with this commit.

Resolves #1109
    
Signed-off-by: Rose Judge <rjudge@vmware.com>