### PR TITLE
Do not add selinux xattrs to file data

### DIFF
--- a/tern/classes/image_layer.py
+++ b/tern/classes/image_layer.py
@@ -359,7 +359,8 @@ class ImageLayer:
                 xattrlist = []
                 xattrline = content.pop(0)
                 while xattrline != '\n':
-                    xattrlist.append(xattrline.strip())
+                    if 'selinux' not in xattrline:
+                        xattrlist.append(xattrline.strip())
                     xattrline = content.pop(0)
                 # when we break out of the extended attributes loop
                 # we combine the results and update the FileData object


### PR DESCRIPTION
selinux extended attributes only manifest themselves if selinux
is enabled on the host machine. Hence it does not make sense to
use them to uniquely identify an image layer across host machines.
This commit checks to see if 'selinux' does not exist in the
extended attribute before appending it to the xattrlist list.

Fixes #108

Signed-off-by: nisha <nisha@ctlfsh.tech>