### PR TITLE
linting: Rename pep8 and pep257

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -5,12 +5,12 @@
 strictness: medium
 test-warnings: false
 
-pep8:
+pycodestyle:
   full: true
   disable:
     - N802 # pep8-naming: function name should be lower case
 
-pep257:
+pydocstyle:
   run: false
 
 pylint:


### PR DESCRIPTION
Prospector version 1.7 detects pep8 and pep257 as outdated names
and throws an error when using these names. As per the instructions,
this commit renames pep8 to pycodestyle and pep257 to pydocstyle.

Signed-off-by: nisha <nisha@ctlfsh.tech>