### PR TITLE
Correction of the purl generation for apk package

### DIFF
--- a/tern/formats/cyclonedx/cyclonedxjson/package_helpers.py
+++ b/tern/formats/cyclonedx/cyclonedxjson/package_helpers.py
@@ -23,7 +23,10 @@ def get_package_dict(os_guess, package):
     purl_type = package.pkg_format
     purl_namespace = cyclonedx_common.get_purl_namespace(os_guess, package.pkg_format)
     if purl_type:
-        purl = PackageURL(purl_type, purl_namespace, package.name, package.version)
+        if purl_type=="apk":
+            purl = PackageURL(purl_namespace, package.name, package.version)
+        else:
+            purl = PackageURL(purl_type,purl_namespace, package.name, package.version)
         package_dict['purl'] = str(purl)
 
     if package.pkg_license:


### PR DESCRIPTION
The purl generation for apk packages was faulty.
For example the purl for alpine busybox was pkg:apk/alpine/busybox@1.31.1-r9
instead of pkg:alpine/busybox@1.31.1-r9.
Here are the result in the OSSINDEX base with the two purls:
- https://ossindex.sonatype.org/component/pkg:apk/alpine/busybox@1.31.1-r9
- https://ossindex.sonatype.org/component/pkg:alpine/busybox@1.31.1-r9

Resolves: #1131

Signed-off-by: Thiéfaine Mercier <thiefaine.mercier@avisto.com>