### PR TITLE
Modification of package format for pip

### DIFF
--- a/tern/analyze/default/command_lib/base.yml
+++ b/tern/analyze/default/command_lib/base.yml
@@ -275,7 +275,7 @@ rpm:
     delimiter: "\n"
 # pip ----------------------------------------------------------------------
 pip:
-  pkg_format: 'pip'
+  pkg_format: 'pypi'
   os_guess:
     - 'None'
   path:
@@ -318,7 +318,7 @@ pip:
     delimiter: "\n"
 # pip3 ----------------------------------------------------------------------
 pip3:
-  pkg_format: 'pip'
+  pkg_format: 'pypi'
   os_guess:
     - 'None'
   path:


### PR DESCRIPTION
Packages download with pip or pip3 are taken from the index Pypi.
To be more accurate for the purl / in general, it could be better to use Pypi
to describe the packages format.
Here for the purl for a python component:
- https://ossindex.sonatype.org/component/pkg:pip/pip-tools
- https://ossindex.sonatype.org/component/pkg:pypi/pip-tools

The scond one is recognized but not the first.

Resolves: #1130

Signed-off-by: Thiéfaine Mercier <thiefaine.mercier@avisto.com>