### PR TITLE
Make licenses data OWASP compatible

### DIFF
--- a/tern/formats/cyclonedx/cyclonedx_common.py
+++ b/tern/formats/cyclonedx/cyclonedx_common.py
@@ -72,4 +72,4 @@ def get_os_guess(image_obj):
 
 
 def get_license_from_name(name):
-    return {'license': {'name': name}}
+    return {'license': {'id': name}}


### PR DESCRIPTION
Previously, license data was output in the format:
```
"licenses": [
  {
    "license": {
      "name": "MIT"
    }
  }
]
```
which was creating parsing problems on some platforms.

This changes "name" to "id" in order to create compatible output

Resolves #1137
