### PR TITLE
Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ Tern does not have its own file level license scanner. In order to fill in the g
 NOTE: Neither the Docker container nor the Vagrant image has any of the extensions installed. You are welcomed to modify `Dockerfile` and `vagrant/bootstrap.sh` to install the extensions if you wish to use them. Please see the instructions below on how to enable the extension of your choice.
 
 ## Scancode<a name="scancode">
-[scancode-toolkit](https://github.com/nexB/scancode-toolkit) is a license analysis tool that "detects licenses, copyrights, package manifests and direct dependencies and more both in source code and binary files". Note that Scancode currently works on Python 3.5 and 3.6 but not 3.7 onwards. Be sure to check what python version you are using below.
+[scancode-toolkit](https://github.com/nexB/scancode-toolkit) is a license analysis tool that "detects licenses, copyrights, package manifests and direct dependencies and more both in source code and binary files". Note that Scancode currently works on Python 3.6 to 3.9. Be sure to check what python version you are using below.
 
 1. Install system dependencies for Scancode (refer to the [Scancode GitHub repo](https://github.com/nexB/scancode-toolkit) for instructions)
 

--- a/docs/spdx-tag-value-mapping.md
+++ b/docs/spdx-tag-value-mapping.md
@@ -84,7 +84,7 @@ Include once at the beginning of the SPDX document.
 
  §  | SPDX Field name | Tern data model reference | Comments
 ----|-----------------|---------------------------|---------
-2.1 | SPDX Version    | N/A                       | will always be `SPDXVersion: SPDX-2.1`
+2.1 | SPDX Version    | N/A                       | will always be `SPDXVersion: SPDX-2.2`
 2.2 | Data License    | N/A                       | will always be `DataLicense: CC0-1.0`
 2.3 | SPDX Identifier | N/A                       | will always be `SPDXID: SPDXRef-DOCUMENT`
 2.4 | Document Name   | **TBD**                   | does Tern have a human-readable way to refer to the image or Dockerfile being analyzed?

--- a/docs/spdx-tag-value-overview.md
+++ b/docs/spdx-tag-value-overview.md
@@ -15,7 +15,7 @@ An SPDX document consists of a series of colon-separateed tag/value pairs, one p
 For example, the following tag-value pairs define the version of [the SPDX specification](https://spdx.org/specifications) that is used by the document, and a name for the SPDX document:
 
 ```
-SPDXVersion: SPDX-2.1
+SPDXVersion: SPDX-2.2
 DocumentName: Tern report for Acme Dockerfile
 ```
 


### PR DESCRIPTION
README says:

Note that Scancode currently works on Python 3.5 and 3.6 but not 3.7 onwards

This is no longer true.

https://scancode-toolkit.readthedocs.io/en/latest/getting-started/install.html#prerequisites

ScanCode needs a Python 3.6+ interpreter; We support all Python versions from 3.6 to 3.9.

