### PR TITLE
Remove underscores from SPDXIDs

### DIFF
--- a/tern/formats/spdx/spdx_common.py
+++ b/tern/formats/spdx/spdx_common.py
@@ -134,7 +134,8 @@ def get_package_spdxref(package_obj):
         src_ref = spdx_formats.package_id.format(name=package_obj.src_name,
                                                  ver=src_ver)
     # replace all the strings that SPDX doesn't like
-    clean_pkg_ref = re.sub(r'[:+~]', r'-', pkg_ref)
+    # allowed characters are: letters, numbers, "." and "-"
+    clean_pkg_ref = re.sub(r'[:+~_]', r'-', pkg_ref)
     if src_ref:
         clean_src_ref = re.sub(r'[:+~]', r'-', src_ref)
         return 'SPDXRef-{}'.format(clean_pkg_ref), 'SPDXRef-{}'.format(clean_src_ref)


### PR DESCRIPTION
An SPDXID is generated using the package name and version metadta. Some
versions, however, contain an underscore in them and an SPDXID cannot
contain an underscore character. This commit replaces underscores in
SPDXIDs with a dash.

Resolves #1143

Signed-off-by: Marc-Etienne Vargenau <marc-etienne.vargenau@nokia.com>
Signed-off-by: Rose Judge <rjudge@vmware.com>