### PR TITLE
Update SPDX-2.1 references to SPDX-2.2

### DIFF
--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -7,7 +7,7 @@
 
 
 We will also continue to work on the following:
-- We will continue to support the SPDX format for container images. To that end, we will make changes to update the format of the document as the [spec](https://spdx.org/sites/cpstandard/files/pages/files/spdxversion2.1.pdf) evolves.
+- We will continue to support the SPDX format for container images. To that end, we will make changes to update the format of the document as the [spec](https://spdx.github.io/spdx-spec/) evolves.
 - As usual, we will continue to work on our technical debt and bug fixes.
 
 This timetable is based on time, resources and feedback from you and will change accordingly.

--- a/docs/spdx-tag-value-mapping.md
+++ b/docs/spdx-tag-value-mapping.md
@@ -6,7 +6,7 @@ This file describes a potential mapping between Tern's data structures and the r
 
 In particular, it will focus on highlighting any necessary data items that are deemed "mandatory" by the SPDX specification.
 
-Version 2.1 of [the SPDX specification](https://spdx.org/specifications) will be used, since it is the most recent minor release. Relevant details of the SPDX tag-value format can be found in [the overview document](spdx-tag-value-overview.md) in this directory.
+Version 2.2 of [the SPDX specification](https://spdx.org/specifications) will be used, since it is the most recent minor release. Relevant details of the SPDX tag-value format can be found in [the overview document](spdx-tag-value-overview.md) in this directory.
 
 ## Relevant Fields
 
@@ -14,7 +14,7 @@ The following table contains (1) all fields that are designated by the SPDX spec
 
 Thoughts on mapping these fields to Tern's data model are described in the **Mapping** section below.
 
-Section (§) numbers are references to the relevant portions of [the SPDX specification](https://spdx.org/specifications), version 2.1. Examples should be assumed to be on a single line, though a Markdown formatter might split them across lines.
+Section (§) numbers are references to the relevant portions of [the SPDX specification](https://spdx.org/specifications), version 2.2. Examples should be assumed to be on a single line, though a Markdown formatter might split them across lines.
 
 ### Document Creation
 
@@ -22,13 +22,13 @@ The following fields should appear *once*, at the beginning of the SPDX document
 
  §  | SPDX Field name | Mandatory? | Brief description    | Example
 ----|-----------------|------------|----------------------|---------
-2.1 | SPDX Version    |    Yes     | version of SPDX spec | `SPDXVersion: SPDX-2.1`
+2.1 | SPDX Version    |    Yes     | version of SPDX spec | `SPDXVersion: SPDX-2.2`
 2.2 | Data License    |    Yes     | license for SPDX metadata in the document itself; always `CC0-1.0` | `DataLicense: CC0-1.0`
 2.3 | SPDX Identifier |    Yes     | identifier for the SPDX document itself; always `SPDXRef-DOCUMENT` | `SPDXID: SPDXRef-DOCUMENT`
 2.4 | Document Name   |    Yes     | human-readable name for the SPDX document itself | `DocumentName: Tern report for ACME Dockerfile`
 2.5 | SPDX Document Namespace | Yes| unique absolute URI for the SPDX document itself | `DocumentNamespace: https://example.com/spdxdocs/tern-report-ACME-1.0.1-123456`
-2.7 | License List Version    | No | release version of the SPDX License List being used | `LicenseListVersion: 3.4`
-2.8 | Creator         |    Yes     | one or more people, orgs or tools used to create the SPDX document | `Creator: Tool: tern-0.4.0`
+2.7 | License List Version    | No | release version of the SPDX License List being used | `LicenseListVersion: 3.16`
+2.8 | Creator         |    Yes     | one or more people, orgs or tools used to create the SPDX document | `Creator: Tool: tern-2.10`
 2.9 | Created         |    Yes     | the time and date when the SPDX document was created (ISO 8601; UTC) | `Created: 2019-03-15T08:25:00Z`
 
 ### Package
@@ -84,7 +84,7 @@ Include once at the beginning of the SPDX document.
 
  §  | SPDX Field name | Tern data model reference | Comments
 ----|-----------------|---------------------------|---------
-2.1 | SPDX Version    | N/A                       | will always be `SPDXVersion: SPDX-2.1`
+2.1 | SPDX Version    | N/A                       | will always be `SPDXVersion: SPDX-2.2`
 2.2 | Data License    | N/A                       | will always be `DataLicense: CC0-1.0`
 2.3 | SPDX Identifier | N/A                       | will always be `SPDXID: SPDXRef-DOCUMENT`
 2.4 | Document Name   | **TBD**                   | does Tern have a human-readable way to refer to the image or Dockerfile being analyzed?

--- a/docs/spdx-tag-value-overview.md
+++ b/docs/spdx-tag-value-overview.md
@@ -15,7 +15,7 @@ An SPDX document consists of a series of colon-separateed tag/value pairs, one p
 For example, the following tag-value pairs define the version of [the SPDX specification](https://spdx.org/specifications) that is used by the document, and a name for the SPDX document:
 
 ```
-SPDXVersion: SPDX-2.1
+SPDXVersion: SPDX-2.2
 DocumentName: Tern report for Acme Dockerfile
 ```
 

--- a/tern/formats/spdx/spdx_common.py
+++ b/tern/formats/spdx/spdx_common.py
@@ -94,7 +94,7 @@ def get_layer_spdxref_snapshot(timestamp):
 def get_layer_verification_code(layer_obj):
     '''Calculate the verification code from the files in an image layer. This
     assumes that layer_obj.files_analyzed is True. The implementation follows
-    the algorithm in the SPDX spec v 2.1 which requires SHA1 to be used to
+    the algorithm in the SPDX spec v 2.2 which requires SHA1 to be used to
     calculate the checksums of the file and the final verification code'''
     sha1_list = []
     for filedata in layer_obj.files:


### PR DESCRIPTION
This commit updates Tern documentation to reflect the current version
of the SPDX spec, SPDX-2.2.

Signed-off-by: Marc-Etienne Vargenau <marc-etienne.vargenau@nokia.com>
Signed-off-by: Rose Judge <rjudge@vmware.com>