### PR TITLE
Correctly lowercase purl package names

### DIFF
--- a/tern/formats/cyclonedx/cyclonedx_common.py
+++ b/tern/formats/cyclonedx/cyclonedx_common.py
@@ -40,9 +40,28 @@ purl_types_with_namespaces = [
 ]
 
 
+purl_names_in_lowercase = [
+    'deb',
+    'go',
+    'npm',
+    'pypi',
+    'rpm',
+]
+
+
 def get_serial_number():
     ''' Return a randomly generated CycloneDX BOM serial number '''
     return 'urn:uuid:' + str(uuid.uuid4())
+
+
+def get_purl_name(name, pkg_format):
+    '''Some purl types require that package names always be lowercased. Given
+    a package format and a corresponding name for a package of that format,
+    return a lowercased version of the package name if the purl spec requires
+    it. Otherwise, just return the original package name.'''
+    if pkg_format in purl_names_in_lowercase:
+        return name.lower()
+    return name
 
 
 def get_timestamp():

--- a/tern/formats/cyclonedx/cyclonedxjson/package_helpers.py
+++ b/tern/formats/cyclonedx/cyclonedxjson/package_helpers.py
@@ -23,7 +23,9 @@ def get_package_dict(os_guess, package):
     purl_type = package.pkg_format
     purl_namespace = cyclonedx_common.get_purl_namespace(os_guess, package.pkg_format)
     if purl_type:
-        purl = PackageURL(purl_type, purl_namespace, package.name, package.version)
+        purl_name = cyclonedx_common.get_purl_name(package.name,
+                                                   package.pkg_format)
+        purl = PackageURL(purl_type, purl_namespace, purl_name, package.version)
         package_dict['purl'] = str(purl)
 
     if package.pkg_license:


### PR DESCRIPTION
Some purl types require that package names always be lowercased. This
commit fixes certain use cases for a handful of package managers where
the purl package names were being improperly reported using uppercase
characters.

Resolves: #1140

Signed-off-by: Thiéfaine Mercier <thiefaine.mercier@avisto.com>
Signed-off-by: Rose Judge <rjudge@vmware.com>