### PR TITLE
Correction of the purl generation for apk package

### DIFF
--- a/tern/formats/cyclonedx/cyclonedxjson/package_helpers.py
+++ b/tern/formats/cyclonedx/cyclonedxjson/package_helpers.py
@@ -26,6 +26,9 @@ def get_package_dict(os_guess, package):
         purl_name = cyclonedx_common.get_purl_name(package.name,
                                                    package.pkg_format)
         purl = PackageURL(purl_type, purl_namespace, purl_name, package.version)
+        if purl_type == "apk":
+            # Update purl to remove "apk" from the string
+            purl = PackageURL(purl_namespace, purl_name, package.version)
         package_dict['purl'] = str(purl)
 
     if package.pkg_license:


### PR DESCRIPTION
The purl generation for apk packages was faulty. For example the purl
for an alpine image busybox package was pkg:apk/alpine/busybox@1.31.1-r9
instead of the correct pkg:alpine/busybox@1.31.1-r9.

Note that "apk" type packages are not defined for purl yet,
specifically, but OSSINDEX uses the pkg:alpine[1] notation and purl has
purposely chosen not to use "apk" as an identifier due to a known
conflict with Android which also uses the term apk[2].

[1] https://ossindex.sonatype.org/component/pkg:alpine/busybox@1.31.1-r9
[2] https://github.com/package-url/purl-spec/issues/159#issuecomment-1081087336

Resolves: #1131

Signed-off-by: Thiéfaine Mercier <thiefaine.mercier@avisto.com>
Signed-off-by: Rose Judge <rjudge@vmware.com>