### PR TITLE
Fix logic error in binary detection

### DIFF
--- a/tern/analyze/default/default_common.py
+++ b/tern/analyze/default/default_common.py
@@ -54,12 +54,16 @@ def get_base_bin(first_layer):
     image and looking for known binaries there. Assume that the layer has
     already been unpacked with the filesystem'''
     binary = ''
+    found = False
     cwd = first_layer.get_untar_dir()
     for key, value in command_lib.command_lib['base'].items():
         for path in value['path']:
             if os.path.exists(os.path.join(cwd, path)):
                 binary = key
+                found = True
                 break
+        if found:
+            break
     return binary
 
 


### PR DESCRIPTION
The `get_base_bin()` function in `default_common.py` iterates through
all of the entries in base.yml and for each entry checks the existence
of each 'path' value in order to locate a valid binary. When the first
binary path is located, Tern should break out of both loops and return
the found binary value. However, due to a logic oversight Tern was only
breaking out of the first loop which meant the function continued to
look for valid binary paths, even after one was found.

For most base OSes this is not an issue because additional binary paths
will not exist. For certain base OSes like photon, however, this was
problematic because both `tdnf` and `rpm` binary paths exist even though
only the `tdnf` binary actually works for package metadata collection.

This commit adds code to break out of the second loop once a valid
binary is found.

Resolves #1156

Signed-off-by: Rose Judge <rjudge@vmware.com>