### PR TITLE
Update license data to show actual license type instead of license ref

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ regex>=2022.3
 GitPython~=3.1
 prettytable~=3.2
 packageurl-python>=0.9.9
+license_expression>=21.6.14

--- a/tern/formats/spdx/spdx_common.py
+++ b/tern/formats/spdx/spdx_common.py
@@ -13,6 +13,7 @@ import logging
 import re
 import uuid
 
+from license_expression import get_spdx_licensing
 from tern.utils import constants
 from tern.formats.spdx.spdxtagvalue import formats as spdx_formats
 
@@ -42,6 +43,14 @@ def get_string_id(string):
 def get_license_ref(license_string):
     """ For SPDX tag-value format, return a LicenseRef string """
     return 'LicenseRef-' + get_string_id(license_string)
+
+def is_spdx_license_expression(license_data):
+    '''Return True if the license is a valid SPDX license expression, else
+    return False'''
+    licensing = get_spdx_licensing()
+    if ',' in license_data:
+        license_data = license_data.replace(',', ' ')
+    return licensing.validate(license_data).errors == []
 
 
 ########################

--- a/tern/formats/spdx/spdx_common.py
+++ b/tern/formats/spdx/spdx_common.py
@@ -49,8 +49,16 @@ def is_spdx_license_expression(license_data):
     return False'''
     licensing = get_spdx_licensing()
     if ',' in license_data:
-        license_data = license_data.replace(',', ' ')
+        license_data = license_data.replace(',', ' and ')
     return licensing.validate(license_data).errors == []
+
+# Searches for declared license data using the license_expression library
+def get_package_license_declared(package_license_declared):
+    if package_license_declared:
+        if is_spdx_license_expression(package_license_declared):
+            return package_license_declared
+        return get_license_ref(package_license_declared)
+    return 'NONE'
 
 
 ########################

--- a/tern/formats/spdx/spdxjson/file_helpers.py
+++ b/tern/formats/spdx/spdxjson/file_helpers.py
@@ -50,7 +50,7 @@ def get_file_dict(filedata, template, layer_id):
         file_license_refs = []
         for lic in spdx_common.get_file_licenses(filedata):
             # Add the LicenseRef to the list instead of license expression
-            file_license_refs.append(spdx_common.get_license_ref(lic))
+            file_license_refs.append(spdx_common.get_package_license_declared(lic))
         file_dict['licenseInfoInFiles'] = file_license_refs
 
     # We only add this if there is a notice

--- a/tern/formats/spdx/spdxjson/image_helpers.py
+++ b/tern/formats/spdx/spdxjson/image_helpers.py
@@ -31,9 +31,10 @@ def get_image_extracted_licenses(image_obj):
                 unique_licenses.add(package.pkg_license)
     extracted_texts = []
     for lic in list(unique_licenses):
-        extracted_texts.append(json_formats.get_extracted_text_dict(
-            extracted_text=lic, license_ref=spdx_common.get_license_ref(
-                lic)))
+        if not spdx_common.is_spdx_license_expression(lic):
+            extracted_texts.append(json_formats.get_extracted_text_dict(
+                extracted_text=lic, license_ref=spdx_common.get_license_ref(
+                    lic)))
     return extracted_texts
 
 

--- a/tern/formats/spdx/spdxjson/layer_helpers.py
+++ b/tern/formats/spdx/spdxjson/layer_helpers.py
@@ -39,9 +39,10 @@ def get_layer_extracted_licenses(layer_obj):
             unique_licenses.add(package.pkg_license)
     extracted_texts = []
     for lic in list(unique_licenses):
-        extracted_texts.append(json_formats.get_extracted_text_dict(
-            extracted_text=lic, license_ref=spdx_common.get_license_ref(
-                lic)))
+        if not spdx_common.is_spdx_license_expression(lic):
+            extracted_texts.append(json_formats.get_extracted_text_dict(
+                extracted_text=lic, license_ref=spdx_common.get_license_ref(
+                    lic)))
     return extracted_texts
 
 

--- a/tern/formats/spdx/spdxjson/package_helpers.py
+++ b/tern/formats/spdx/spdxjson/package_helpers.py
@@ -7,19 +7,9 @@
 Helper functions for packages in SPDX JSON document creation
 """
 
-from license_expression import get_spdx_licensing
 from tern.report import content
 from tern.formats.spdx import spdx_common
 from tern.formats.spdx.spdxjson import formats as json_formats
-
-
-def is_spdx_license_expression(license_data):
-    '''Return True if the license is a valid SPDX license expression, else
-    return False'''
-    licensing = get_spdx_licensing()
-    if ',' in license_data:
-        license_data = license_data.replace(',', ' ')
-    return licensing.validate(license_data).errors == []
 
 
 def get_package_comment(package):
@@ -35,7 +25,7 @@ def get_package_comment(package):
 
 def get_package_license_declared(package_license_declared):
     if package_license_declared:
-        if is_spdx_license_expression(package_license_declared):
+        if spdx_common.is_spdx_license_expression(package_license_declared):
             return package_license_declared
         return spdx_common.get_license_ref(package_license_declared)
     return 'NONE'

--- a/tern/formats/spdx/spdxjson/package_helpers.py
+++ b/tern/formats/spdx/spdxjson/package_helpers.py
@@ -7,9 +7,19 @@
 Helper functions for packages in SPDX JSON document creation
 """
 
+from license_expression import get_spdx_licensing
 from tern.report import content
 from tern.formats.spdx import spdx_common
 from tern.formats.spdx.spdxjson import formats as json_formats
+
+
+def is_spdx_license_expression(license_data):
+    '''Return True if the license is a valid SPDX license expression, else
+    return False'''
+    licensing = get_spdx_licensing()
+    if ',' in license_data:
+        license_data = license_data.replace(',', ' ')
+    return licensing.validate(license_data).errors == []
 
 
 def get_package_comment(package):
@@ -21,6 +31,14 @@ def get_package_comment(package):
             comment = comment + content.print_notices(
                 notice_origin, '', '\t')
     return comment
+
+
+def get_package_license_declared(package_license_declared):
+    if package_license_declared:
+        if is_spdx_license_expression(package_license_declared):
+            return package_license_declared
+        return spdx_common.get_license_ref(package_license_declared)
+    return 'NONE'
 
 
 def get_source_package_dict(package, template):
@@ -39,9 +57,8 @@ def get_source_package_dict(package, template):
         mapping['PackageDownloadLocation'] else 'NOASSERTION',
         'filesAnalyzed': False,  # always false for packages
         'licenseConcluded': 'NOASSERTION',  # always NOASSERTION
-        'licenseDeclared': spdx_common.get_license_ref(
-            mapping['PackageLicenseDeclared']) if
-        mapping['PackageLicenseDeclared'] else 'NONE',
+        'licenseDeclared': get_package_license_declared(
+            mapping['PackageLicenseDeclared']),
         'copyrightText': mapping['PackageCopyrightText'] if
         mapping['PackageCopyrightText'] else'NONE',
         'comment': json_formats.source_package_comment
@@ -65,9 +82,8 @@ def get_package_dict(package, template):
         mapping['PackageDownloadLocation'] else 'NOASSERTION',
         'filesAnalyzed': False,  # always false for packages
         'licenseConcluded': 'NOASSERTION',  # always NOASSERTION
-        'licenseDeclared': spdx_common.get_license_ref(
-            mapping['PackageLicenseDeclared']) if
-        mapping['PackageLicenseDeclared'] else 'NONE',
+        'licenseDeclared':  get_package_license_declared(
+            mapping['PackageLicenseDeclared']),
         'copyrightText': mapping['PackageCopyrightText'] if
         mapping['PackageCopyrightText'] else'NONE',
         'comment': get_package_comment(package)

--- a/tern/formats/spdx/spdxjson/package_helpers.py
+++ b/tern/formats/spdx/spdxjson/package_helpers.py
@@ -23,14 +23,6 @@ def get_package_comment(package):
     return comment
 
 
-def get_package_license_declared(package_license_declared):
-    if package_license_declared:
-        if spdx_common.is_spdx_license_expression(package_license_declared):
-            return package_license_declared
-        return spdx_common.get_license_ref(package_license_declared)
-    return 'NONE'
-
-
 def get_source_package_dict(package, template):
     '''''Given a package object and its SPDX template mapping, return a SPDX
     JSON dictionary representation of the associated source package.
@@ -47,7 +39,7 @@ def get_source_package_dict(package, template):
         mapping['PackageDownloadLocation'] else 'NOASSERTION',
         'filesAnalyzed': False,  # always false for packages
         'licenseConcluded': 'NOASSERTION',  # always NOASSERTION
-        'licenseDeclared': get_package_license_declared(
+        'licenseDeclared': spdx_common.get_package_license_declared(
             mapping['PackageLicenseDeclared']),
         'copyrightText': mapping['PackageCopyrightText'] if
         mapping['PackageCopyrightText'] else'NONE',
@@ -72,7 +64,7 @@ def get_package_dict(package, template):
         mapping['PackageDownloadLocation'] else 'NOASSERTION',
         'filesAnalyzed': False,  # always false for packages
         'licenseConcluded': 'NOASSERTION',  # always NOASSERTION
-        'licenseDeclared':  get_package_license_declared(
+        'licenseDeclared':  spdx_common.get_package_license_declared(
             mapping['PackageLicenseDeclared']),
         'copyrightText': mapping['PackageCopyrightText'] if
         mapping['PackageCopyrightText'] else'NONE',

--- a/tern/formats/spdx/spdxtagvalue/file_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/file_helpers.py
@@ -35,7 +35,7 @@ def get_license_info_block(filedata):
     else:
         for lic in spdx_common.get_file_licenses(filedata):
             block = block + 'LicenseInfoInFile: {}'.format(
-                spdx_common.get_license_ref(lic)) + '\n'
+                spdx_common.get_package_license_declared(lic)) + '\n'
     return block
 
 

--- a/tern/formats/spdx/spdxtagvalue/image_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/image_helpers.py
@@ -57,9 +57,10 @@ def get_image_packages_license_block(image_obj):
             if package.pkg_license:
                 licenses.add(package.pkg_license)
     for lic in licenses:
-        block += spdx_formats.license_id.format(
-            license_ref=spdx_common.get_license_ref(lic)) + '\n'
-        block += spdx_formats.extracted_text.format(orig_license=lic) + '\n'
+        if not spdx_common.is_spdx_license_expression(lic):
+            block += spdx_formats.license_id.format(
+                license_ref=spdx_common.get_license_ref(lic)) + '\n'
+            block += spdx_formats.extracted_text.format(orig_license=lic) + '\n'
     return block
 
 
@@ -74,9 +75,10 @@ def get_image_file_license_block(image_obj):
             for lic in spdx_common.get_layer_licenses(layer):
                 licenses.add(lic)
     for lic in licenses:
-        block += spdx_formats.license_id.format(
-            license_ref=spdx_common.get_license_ref(lic)) + '\n'
-        block += spdx_formats.extracted_text.format(orig_license=lic) + '\n'
+        if not spdx_common.is_spdx_license_expression(lic):
+            block += spdx_formats.license_id.format(
+                license_ref=spdx_common.get_license_ref(lic)) + '\n'
+            block += spdx_formats.extracted_text.format(orig_license=lic) + '\n'
     return block
 
 

--- a/tern/formats/spdx/spdxtagvalue/package_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/package_helpers.py
@@ -24,14 +24,6 @@ def get_package_comment(package_obj):
     return comment
 
 
-def get_package_license_declared(package_license_declared):
-    if package_license_declared:
-        if spdx_common.is_spdx_license_expression(package_license_declared):
-            return package_license_declared
-        return spdx_common.get_license_ref(package_license_declared)
-    return 'NONE'
-
-
 def get_source_package_block(package_obj, template):
     '''Given a package object and its SPDX template mapping, return a SPDX
     document block for the corresponding source package.
@@ -63,7 +55,7 @@ def get_source_package_block(package_obj, template):
     # Package License Concluded (always NOASSERTION)
     block += 'PackageLicenseConcluded: NOASSERTION\n'
     # Package License Declared (use the license ref for this)
-    block += 'PackageLicenseDeclared: ' + get_package_license_declared(
+    block += 'PackageLicenseDeclared: ' + spdx_common.get_package_license_declared(
         mapping['PackageLicenseDeclared']) + '\n'
     # Package Copyright Text
     if mapping['PackageCopyrightText']:
@@ -105,7 +97,7 @@ def get_package_block(package_obj, template):
     # Package License Concluded (always NOASSERTION)
     block += 'PackageLicenseConcluded: NOASSERTION\n'
     # Package License Declared (use the license ref for this)
-    block += 'PackageLicenseDeclared: ' + get_package_license_declared(
+    block += 'PackageLicenseDeclared: ' + spdx_common.get_package_license_declared(
         mapping['PackageLicenseDeclared']) + '\n'
     # Package Copyright Text
     if mapping['PackageCopyrightText']:

--- a/tern/formats/spdx/spdxtagvalue/package_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/package_helpers.py
@@ -7,19 +7,10 @@
 Helper functions for packages in SPDX document
 """
 
-from license_expression import get_spdx_licensing
 from tern.formats.spdx.spdxtagvalue import formats as spdx_formats
 from tern.formats.spdx import spdx_common
 from tern.report import content
 
-
-def is_spdx_license_expression(license_data):
-    '''Return True if the license is a valid SPDX license expression, else
-    return False'''
-    licensing = get_spdx_licensing()
-    if ',' in license_data:
-        license_data = license_data.replace(',', ' ')
-    return licensing.validate(license_data).errors == []
 
 def get_package_comment(package_obj):
     '''Return a PackageComment tag-value text block for a list of
@@ -35,7 +26,7 @@ def get_package_comment(package_obj):
 
 def get_package_license_declared(package_license_declared):
     if package_license_declared:
-        if is_spdx_license_expression(package_license_declared):
+        if spdx_common.is_spdx_license_expression(package_license_declared):
             return package_license_declared
         return spdx_common.get_license_ref(package_license_declared)
     return 'NONE'

--- a/tern/formats/spdx/spdxtagvalue/package_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/package_helpers.py
@@ -7,10 +7,19 @@
 Helper functions for packages in SPDX document
 """
 
+from license_expression import get_spdx_licensing
 from tern.formats.spdx.spdxtagvalue import formats as spdx_formats
 from tern.formats.spdx import spdx_common
 from tern.report import content
 
+
+def is_spdx_license_expression(license_data):
+    '''Return True if the license is a valid SPDX license expression, else
+    return False'''
+    licensing = get_spdx_licensing()
+    if ',' in license_data:
+        license_data = license_data.replace(',', ' ')
+    return licensing.validate(license_data).errors == []
 
 def get_package_comment(package_obj):
     '''Return a PackageComment tag-value text block for a list of
@@ -22,6 +31,14 @@ def get_package_comment(package_obj):
                 notice_origin, '', '\t')
         return spdx_formats.package_comment.format(comment=comment)
     return comment
+
+
+def get_package_license_declared(package_license_declared):
+    if package_license_declared:
+        if is_spdx_license_expression(package_license_declared):
+            return package_license_declared
+        return spdx_common.get_license_ref(package_license_declared)
+    return 'NONE'
 
 
 def get_source_package_block(package_obj, template):
@@ -55,11 +72,8 @@ def get_source_package_block(package_obj, template):
     # Package License Concluded (always NOASSERTION)
     block += 'PackageLicenseConcluded: NOASSERTION\n'
     # Package License Declared (use the license ref for this)
-    if mapping['PackageLicenseDeclared']:
-        block += 'PackageLicenseDeclared: {}\n'.format(
-            spdx_common.get_license_ref(mapping['PackageLicenseDeclared']))
-    else:
-        block += 'PackageLicenseDeclared: NONE\n'
+    block += 'PackageLicenseDeclared: ' + get_package_license_declared(
+        mapping['PackageLicenseDeclared']) + '\n'
     # Package Copyright Text
     if mapping['PackageCopyrightText']:
         block += 'PackageCopyrightText:' + spdx_formats.block_text.format(
@@ -100,11 +114,8 @@ def get_package_block(package_obj, template):
     # Package License Concluded (always NOASSERTION)
     block += 'PackageLicenseConcluded: NOASSERTION\n'
     # Package License Declared (use the license ref for this)
-    if mapping['PackageLicenseDeclared']:
-        block += 'PackageLicenseDeclared: {}\n'.format(
-            spdx_common.get_license_ref(mapping['PackageLicenseDeclared']))
-    else:
-        block += 'PackageLicenseDeclared: NONE\n'
+    block += 'PackageLicenseDeclared: ' + get_package_license_declared(
+        mapping['PackageLicenseDeclared']) + '\n'
     # Package Copyright Text
     if mapping['PackageCopyrightText']:
         block += 'PackageCopyrightText:' + spdx_formats.block_text.format(


### PR DESCRIPTION
Previously the `PackageLicenseDeclared` and `licenseDeclared` data 
for `spdxtagvalue` and  `spdxjson` respectively were set to license reference
of type `LicenseRef-df8cb33` which is not informative. This change updates
that data to the actual license info, f.e. `MIT`, in case a license is declared,
or the `LicenseRef-df8cb33` value if it's not

Resolves #1147