### PR TITLE
Add subdir for tar files in the working dir

### DIFF
--- a/tern/classes/image_layer.py
+++ b/tern/classes/image_layer.py
@@ -318,8 +318,18 @@ class ImageLayer:
         """Get the directory where contents of the image layer are untarred"""
         # the untar directory is based on the image layout
         if self.image_layout == 'docker':
+            # Images built with Kaniko and its tarPath parameter identify
+            # as Docker image based on the metadata format, but keep their
+            # layer tar files in the root of the main tar file.
+            # So we will make sure if there's no subdir for the layer tar
+            # files, we use the first part of the file name as dir name.
+            # This is to prevent overwriting the extracted layers on every
+            # subsequent layer inspection.
+            subdir_name = os.path.dirname(self.tar_file)
+            if not subdir_name:
+                subdir_name = self.tar_file.split('.', 1)[0]
             return os.path.join(rootfs.get_working_dir(),
-                                os.path.dirname(self.tar_file),
+                                subdir_name,
                                 constants.untar_dir)
         # For OCI layouts, the tar file may be at the root of the directory
         # So we will return a path one level deeper

--- a/tests/test_class_image_layer.py
+++ b/tests/test_class_image_layer.py
@@ -165,6 +165,12 @@ class TestClassImageLayer(unittest.TestCase):
         expected_path = os.path.join(rootfs.get_working_dir(),
                                      'path/to/contents')
         self.assertEqual(self.layer.get_untar_dir(), expected_path)
+        # Kaniko image format test
+        self.layer = ImageLayer('123abc', 'some_layer_tar_file.tar.gz')
+        self.layer.image_layout = "docker"
+        expected_path = os.path.join(rootfs.get_working_dir(),
+                                     'some_layer_tar_file/contents')
+        self.assertEqual(self.layer.get_untar_dir(), expected_path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The safeguard of adding a subdir based on the first part of the
file name is necessary for docker-like image tar archives,
which don't have a folder for each layer but rather another tar.gz
file or similar. This is the case for kaniko built docker image
archives.

Without it, tar archives will overwrite the untar_dir on every new
layer analyzed. This will result in the os-release file not being
found as the os analyzer expects the files of the first layer
in the dir but it's actually the files of the last dir.

Signed-off-by: Roger Lehmann <roger.lehmann@newtron.de>