### PR TITLE
Fix error executing in chroot in Ubuntu container

### DIFF
--- a/tern/analyze/default/default_common.py
+++ b/tern/analyze/default/default_common.py
@@ -34,6 +34,13 @@ def find_shell(fspath):
         if realpath[0] == '/' and os.path.exists(os.path.join(fspath,
                                                               realpath[1:])):
             return sh
+        # In some cases, the realpath for a symlink incorrectly resolves to
+        # /usr/<path>. In these cases, ignore the /usr/ prefix and look for
+        # the linked binary in the current working dir.
+        # See issue #1161 for details.
+        if realpath[0] == '/' and os.path.exists(os.path.join(fspath,
+                                                              realpath[5:])):
+            return sh
         # otherwise, just follow symlink in same folder and
         # remove leading forwardslash before joining paths
         if os.path.exists(os.path.join(fspath, sh[1:])):


### PR DESCRIPTION
When Tern ran in a Ubuntu container for images with an `apk` package
manager, there was an issue finding the shell which led to a failed
package metadata command using chroot.

This commit adds a workaround to make sure Tern can find a shell when
running in a Ubuntu container, specifically when the shell is symlinked
to busybox for the container being analyzed. A more detailed description
of the problem can be found in the bug report[1].

It's unclear exactly why the realpath fails to resolve to the correct
utility location when Tern runs in a Ubuntu container while analyzing
apk-based container images. For now, this commit is meant as a
workaround for this exceptional case that is blocking several users.

[1]https://github.com/tern-tools/tern/issues/1161

Resolves #1161

Signed-off-by: Rose Judge <rjudge@vmware.com>