### PR TITLE
whitespace after keyword

### DIFF
--- a/tern/formats/spdx/spdxjson/package_helpers.py
+++ b/tern/formats/spdx/spdxjson/package_helpers.py
@@ -42,7 +42,7 @@ def get_source_package_dict(package, template):
         'licenseDeclared': spdx_common.get_package_license_declared(
             mapping['PackageLicenseDeclared']),
         'copyrightText': mapping['PackageCopyrightText'] if
-        mapping['PackageCopyrightText'] else'NONE',
+        mapping['PackageCopyrightText'] else 'NONE',
         'comment': json_formats.source_package_comment
     }
 
@@ -67,7 +67,7 @@ def get_package_dict(package, template):
         'licenseDeclared':  spdx_common.get_package_license_declared(
             mapping['PackageLicenseDeclared']),
         'copyrightText': mapping['PackageCopyrightText'] if
-        mapping['PackageCopyrightText'] else'NONE',
+        mapping['PackageCopyrightText'] else 'NONE',
         'comment': get_package_comment(package)
     }
 


### PR DESCRIPTION
In tern/formats/spdx/spdxjson/package_helpers.py, add whitespace after keyword.

Signed-off-by: Marc-Etienne Vargenau <marc-etienne.vargenau@nokia.com>