### PR TITLE
Add functionality to pull local images with skopeo

### DIFF
--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -180,7 +180,9 @@ def main():
                                " image")
     parser_report.add_argument('-i', '--image',
                                help="A container image referred either by "
-                               " repo:tag or repo@digest-type:digest")
+                               " repo:tag or repo@digest-type:digest. To "
+                               "analyze a local image, prefix the container "
+                               "image with 'docker-daemon:'")
     parser_report.add_argument('--no-tls', default=False,
                                action='store_true',
                                help="When fetching an image, DO NOT use HTTPS "

--- a/tern/load/skopeo.py
+++ b/tern/load/skopeo.py
@@ -33,6 +33,9 @@ def pull_image(image_tag_string, no_tls=False):
     check_skopeo_setup()
     # we will assume the docker transport for now
     remote = f'docker://{image_tag_string}'
+    # Unless the user specifies that the image is local
+    if image_tag_string.split(':')[0] == "docker-daemon":
+        remote = image_tag_string
     local = f'dir:{rootfs.get_working_dir()}'
     logger.debug("Attempting to pull image \"%s\"", image_tag_string)
     if no_tls:
@@ -52,6 +55,8 @@ def get_image_digest(image_tag_string):
     # check if skopeo is set up
     check_skopeo_setup()
     remote = f'docker://{image_tag_string}'
+    if image_tag_string.split(':')[0] == "docker-daemon":
+        remote = image_tag_string
     logger.debug("Inspecting remote image \"%s\"", image_tag_string)
     result, error = rootfs.shell_command(
         False, ['skopeo', 'inspect', remote])


### PR DESCRIPTION
Skopeo has support for local images but Tern currently always pulls the image provided by the user from a repository. This change adds parsing to skopeo.py to enable pulling of local images using skopeo. In order to pull local images, users must prefix their image with `docker-daemon:`. Instructions in the `report` menu have also been updated with instructions on how to pull local images.

Resolves #1191

Signed-off-by: Rui Valim <root@ruivalim.com.br>
Signed-off-by: Rose Judge <rjudge@vmware.com>