### PR TITLE
Replace inalid license key characters

### DIFF
--- a/tern/formats/spdx/spdx_common.py
+++ b/tern/formats/spdx/spdx_common.py
@@ -48,8 +48,9 @@ def is_spdx_license_expression(license_data):
     '''Return True if the license is a valid SPDX license expression, else
     return False'''
     licensing = get_spdx_licensing()
-    if ',' in license_data:
+    if ',' in license_data or '/' in license_data:
         license_data = license_data.replace(',', ' and ')
+        license_data = license_data.replace('/', '-')
     return licensing.validate(license_data).errors == []
 
 def get_package_license_declared(package_license_declared):


### PR DESCRIPTION
When a license is reported with invalid license keys (i.e. anything besides letters and numbers, underscore, dot, colon or hyphen signs and spaces) the `is_spdx_license_expression()` function fails because the liense-expression library does not properly handle the unknown characters. This commit is a workaround until the issue opened in the license-expression library[1] is resolved.

Resolves #1199

[1] https://github.com/nexB/license-expression/issues/76

Signed-off-by: Rose Judge <rjudge@vmware.com>