### PR TITLE
Add version info to layer Packages in SPDX reports

### DIFF
--- a/tern/formats/spdx/spdxjson/layer_helpers.py
+++ b/tern/formats/spdx/spdxjson/layer_helpers.py
@@ -149,6 +149,7 @@ def get_layer_dict(layer_obj):
     layer_dict = {
         'name': os.path.basename(layer_obj.tar_file),
         'SPDXID': spdx_common.get_layer_spdxref(layer_obj),
+        'versionInfo': layer_obj.layer_index,
         'packageFileName': layer_obj.tar_file,
         'downloadLocation': 'NONE',
         'filesAnalyzed': bool(layer_obj.files_analyzed),

--- a/tern/formats/spdx/spdxtagvalue/layer_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/layer_helpers.py
@@ -115,6 +115,8 @@ def get_layer_block(layer_obj, template):
     block += 'PackageName: {}\n'.format(os.path.basename(layer_obj.tar_file))
     # Package SPDXID
     block += 'SPDXID: {}\n'.format(spdx_common.get_layer_spdxref(layer_obj))
+    # Package Version. For Layer objects, this is just the layer_index
+    block += 'PackageVersion: {}\n'.format(layer_obj.layer_index)
     # Package File Name
     block += 'PackageFileName: {}\n'.format(layer_obj.tar_file)
     # Package Download Location (always NONE for layers)


### PR DESCRIPTION
The NTIA minimum requirements for an SBOM require that all Packages have version information. Since Tern represents container layers as SPDX Packages, these package elements must have version information in order to satisfy NTIA minimums. This commit adds version information to layer "Packages" using the layer indexes (i.e. the base OS layer has version "1")

Works towards #1205

Signed-off-by: Rose Judge <rjudge@vmware.com>