### PR TITLE
Add package supplier info to Tern reports

### DIFF
--- a/tern/analyze/default/bundle.py
+++ b/tern/analyze/default/bundle.py
@@ -52,7 +52,8 @@ def convert_to_pkg_dicts(attr_lists):
                'pkg_licenses': 'pkg_licenses',
                'files': 'files',
                'src_name': 'source_names',
-               'src_version': 'source_versions'}
+               'src_version': 'source_versions',
+               'pkg_supplier': 'pkg_suppliers'}
     pkg_list = []
     len_names = len(attr_lists['names'])
     # make a list of keys that correspond with package property names

--- a/tern/analyze/default/command_lib/base.yml
+++ b/tern/analyze/default/command_lib/base.yml
@@ -88,6 +88,14 @@ dpkg:
         container:
           - "dpkg-query -W -f '${Version}\n'"
     delimiter: "\n"
+  pkg_suppliers:
+    invoke:
+      1:
+        container:
+          - "distro=`/bin/cat /etc/os-release | grep NAME | sed -n '2p' | cut -f 2 -d '=' | cut -d '\"' -f2`"
+          - "pkgs=`dpkg-query -W -f '${Package}\n'`"
+          - "for p in $pkgs; do echo $distro; done"
+    delimiter: "\n"
   source_names:
     invoke:
       1:
@@ -148,6 +156,13 @@ apk:
           - "pkgs=`apk info 2>/dev/null`"
           - "for p in $pkgs; do lic=`apk info $p 2>/dev/null | head -1 | awk '{print $1}'`; echo $lic | sed -e \"s/^$p-//\"; done"
     delimiter: "\n"
+  pkg_suppliers:
+    invoke:
+      1:
+        container:
+          - "pkgs=`apk info 2>/dev/null`"
+          - "for p in $pkgs; do echo 'Alpine Linux'; done"
+    delimiter: "\n"
   licenses:
     invoke:
       1:
@@ -191,6 +206,13 @@ pacman:
       1:
         container:
           - 'pacman -Q 2>/dev/null | cut -f 2 -d " "'
+    delimiter: "\n"
+  pkg_suppliers:
+    invoke:
+      1:
+        container:
+          - 'pkgs=`pacman -Qq 2>/dev/null`'
+          - 'for p in $pkgs; do echo "Arch Linux"; done'
     delimiter: "\n"
   licenses:
     invoke:
@@ -237,6 +259,14 @@ rpm:
       1:
         container:
           - 'rpm --query --all --queryformat "%{version}\n" 2>/dev/null'
+    delimiter: "\n"
+  pkg_suppliers:
+    invoke:
+      1:
+        container:
+          - "distro=`/bin/cat /etc/os-release | grep NAME | sed -n '1p' | cut -f 2 -d '=' | cut -d '\"' -f2`"
+          - "pkgs=`rpm --query --all --queryformat \"%{name}\n\" 2>/dev/null`"
+          - "for p in $pkgs; do echo $distro; done"
     delimiter: "\n"
   licenses:
     invoke:
@@ -302,6 +332,13 @@ pip:
           - "pkgs=`pip list --format=freeze 2> /dev/null | cut -f1 -d'='`"
           - "for p in $pkgs; do pip show $p 2> /dev/null | head -2 | tail -1 | cut -f2 -d' '; done"
     delimiter: "\n"
+  pkg_suppliers:
+    invoke:
+      1:
+        container:
+          - "pkgs=`pip list --format=freeze 2> /dev/null | cut -f1 -d'='`"
+          - "for p in $pkgs; do echo 'PyPI'; done"
+    delimiter: "\n"
   licenses:
     invoke:
       1:
@@ -344,6 +381,13 @@ pip3:
         container:
           - "pkgs=`pip3 list --format=freeze 2> /dev/null | cut -f1 -d'='`"
           - "for p in $pkgs; do pip3 show $p 2> /dev/null | head -2 | tail -1 | cut -f2 -d' '; done"
+    delimiter: "\n"
+  pkg_suppliers:
+    invoke:
+      1:
+        container:
+          - "pkgs=`pip3 list --format=freeze 2> /dev/null | cut -f1 -d'='`"
+          - "for p in $pkgs; do echo 'PyPI'; done"
     delimiter: "\n"
   licenses:
     invoke:

--- a/tern/analyze/default/command_lib/command_lib.py
+++ b/tern/analyze/default/command_lib/command_lib.py
@@ -37,9 +37,10 @@ with open(os.path.abspath(snippet_file), encoding='utf-8') as f:
     command_lib['snippets'] = yaml.safe_load(f)
 # list of package information keys that the command library can accomodate
 base_keys = {'names', 'versions', 'licenses', 'source_names',
-             'source_versions', 'copyrights', 'proj_urls', 'srcs', 'files'}
+             'source_versions', 'pkg_suppliers', 'copyrights',
+             'proj_urls', 'srcs', 'files'}
 package_keys = {'name', 'version', 'license', 'src_name', 'src_version',
-                'copyright', 'proj_url', 'src', 'files'}
+               'pkg_supplier', 'copyright', 'proj_url', 'src', 'files'}
 
 # global logger
 logger = logging.getLogger(constants.logger_name)

--- a/tern/classes/package.py
+++ b/tern/classes/package.py
@@ -24,6 +24,8 @@ class Package:
         pkg_licenses: all licenses found within a package
         src_name: the source package associated with the binary package
         src_version: the source package version
+        pkg_supplier: the package distributor according to SPDX 7.5;
+        required to create NTIA compliant SPDX docs
 
     methods:
         to_dict: returns a dict representation of the instance
@@ -47,6 +49,7 @@ class Package:
         self.__pkg_format = ''
         self.__src_name = ''
         self.__src_version = ''
+        self.__pkg_supplier = ''
 
     @property
     def name(self):
@@ -144,6 +147,14 @@ class Package:
     def src_version(self, src_version):
         self.__src_version = src_version
 
+    @property
+    def pkg_supplier(self):
+        return self.__pkg_supplier
+
+    @pkg_supplier.setter
+    def pkg_supplier(self, pkg_supplier):
+        self.__pkg_supplier = pkg_supplier
+
     def get_file_paths(self):
         """Return a list of paths of all the files in a package"""
         return [f.path for f in self.__files]
@@ -217,6 +228,7 @@ class Package:
             files: <package files>
             src_name: <source package>
             src_ver: <source package version>
+            pkg_supplier: <package distributor/supplier>
         the way to use this method is to instantiate the class with the
         name and then give it a package dictionary to fill in the rest
         return true if package name is the same as the one used to instantiate

--- a/tern/formats/spdx/spdx.py
+++ b/tern/formats/spdx/spdx.py
@@ -21,7 +21,8 @@ class SPDX(Template):
                 'copyright': 'PackageCopyrightText',
                 'download_url': 'PackageDownloadLocation',
                 'src_name': 'SourcePackageName',
-                'src_version': 'SourcePackageVersion'}
+                'src_version': 'SourcePackageVersion',
+                'pkg_supplier': 'PackageSupplier'}
 
     def image_layer(self):
         return {'tar_file': 'PackageFileName'}

--- a/tern/formats/spdx/spdxjson/image_helpers.py
+++ b/tern/formats/spdx/spdxjson/image_helpers.py
@@ -84,6 +84,7 @@ def get_image_dict(image_obj, template):
         'name': mapping['PackageName'],
         'SPDXID': spdx_common.get_image_spdxref(image_obj),
         'versionInfo': mapping['PackageVersion'],
+        'supplier': 'NOASSERTION',  # always NOASSERTION
         'downloadLocation': 'NOASSERTION',  # always NOASSERTION
         'filesAnalyzed': False,  # always false
         'licenseConcluded': 'NOASSERTION',  # always NOASSERTION

--- a/tern/formats/spdx/spdxjson/layer_helpers.py
+++ b/tern/formats/spdx/spdxjson/layer_helpers.py
@@ -150,6 +150,7 @@ def get_layer_dict(layer_obj):
         'name': os.path.basename(layer_obj.tar_file),
         'SPDXID': spdx_common.get_layer_spdxref(layer_obj),
         'versionInfo': layer_obj.layer_index,
+        'supplier': 'NOASSERTION', # always NOASSERTION
         'packageFileName': layer_obj.tar_file,
         'downloadLocation': 'NONE',
         'filesAnalyzed': bool(layer_obj.files_analyzed),

--- a/tern/formats/spdx/spdxjson/package_helpers.py
+++ b/tern/formats/spdx/spdxjson/package_helpers.py
@@ -58,12 +58,14 @@ def get_package_dict(package, template):
     JSON dictionary representation of the package. The analyzed files will
     go in a separate dictionary for the JSON document.'''
     mapping = package.to_dict(template)
+    supplier_str = 'Organization: ' + mapping['PackageSupplier']
     pkg_ref, _ = spdx_common.get_package_spdxref(package)
     package_dict = {
         'name': mapping['PackageName'],
         'SPDXID': pkg_ref,
         'versionInfo': mapping['PackageVersion'] if mapping['PackageVersion']
         else 'NOASSERTION',
+        'supplier': supplier_str if mapping['PackageSupplier'] else 'NOASSERTION', 
         'downloadLocation': mapping['PackageDownloadLocation'] if
         mapping['PackageDownloadLocation'] else 'NOASSERTION',
         'filesAnalyzed': False,  # always false for packages

--- a/tern/formats/spdx/spdxtagvalue/image_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/image_helpers.py
@@ -101,6 +101,8 @@ def get_image_block(image_obj, template):
     block += 'SPDXID: {}\n'.format(spdx_common.get_image_spdxref(image_obj))
     # Package Version
     block += 'PackageVersion: {}\n'.format(mapping['PackageVersion'])
+    # Package Supplier (always NOASSERTION)
+    block += 'PackageSupplier: NOASSERTION\n'
     # Package Download Location (always NOASSERTION)
     block += 'PackageDownloadLocation: NOASSERTION\n'
     # Files Analyzed (always false)

--- a/tern/formats/spdx/spdxtagvalue/layer_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/layer_helpers.py
@@ -117,6 +117,8 @@ def get_layer_block(layer_obj, template):
     block += 'SPDXID: {}\n'.format(spdx_common.get_layer_spdxref(layer_obj))
     # Package Version. For Layer objects, this is just the layer_index
     block += 'PackageVersion: {}\n'.format(layer_obj.layer_index)
+    # Package Supplier (always NOASSERTION)
+    block += 'PackageSupplier: NOASSERTION\n'
     # Package File Name
     block += 'PackageFileName: {}\n'.format(layer_obj.tar_file)
     # Package Download Location (always NONE for layers)

--- a/tern/formats/spdx/spdxtagvalue/package_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/package_helpers.py
@@ -86,6 +86,11 @@ def get_package_block(package_obj, template):
     # Package Version
     if mapping['PackageVersion']:
         block += 'PackageVersion: {}\n'.format(mapping['PackageVersion'])
+    # Package Supplier
+    if mapping['PackageSupplier']:
+        block += 'PackageSupplier: Organization: {}\n'.format(mapping['PackageSupplier'])
+    else:
+        block += 'PackageSupplier: NOASSERTION\n'
     # Package Download Location
     if mapping['PackageDownloadLocation']:
         block += 'PackageDownloadLoaction: {}\n'.format(

--- a/tests/test_class_package.py
+++ b/tests/test_class_package.py
@@ -25,6 +25,7 @@ class TestClassPackage(unittest.TestCase):
         self.p1.pkg_format = 'deb'
         self.p1.src_name = 'p1src'
         self.p1.src_version = '1.0'
+        self.p1.pkg_supplier = 'VMware'
 
         self.p2 = Package('p2')
 
@@ -65,6 +66,8 @@ class TestClassPackage(unittest.TestCase):
                          ('a', '/usr/abc/a'))
         self.assertEqual((self.p2.files[1].name, self.p2.files[1].path),
                          ('b', '/usr/abc/b'))
+        self.p2.pkg_supplier = 'Linux Foundation'
+        self.assertEqual(self.p2.pkg_supplier, 'Linux Foundation')
 
     def testGetters(self):
         self.assertEqual(self.p1.name, 'p1')
@@ -78,6 +81,7 @@ class TestClassPackage(unittest.TestCase):
         self.assertEqual(self.p1.pkg_format, 'deb')
         self.assertEqual(self.p1.src_name, 'p1src')
         self.assertEqual(self.p1.src_version, '1.0')
+        self.assertEqual(self.p1.pkg_supplier, 'VMware')
 
     def testAddFile(self):
         p1 = Package('package')
@@ -130,6 +134,7 @@ class TestClassPackage(unittest.TestCase):
         self.assertEqual(a_dict['pkg_format'], 'deb')
         self.assertEqual(a_dict['src_name'], 'p1src')
         self.assertEqual(a_dict['src_version'], '1.0')
+        self.assertEqual(a_dict['pkg_supplier'], 'VMware')
 
     def testToDictTemplate(self):
         template1 = TestTemplate1()
@@ -175,7 +180,8 @@ class TestClassPackage(unittest.TestCase):
                             {'name': 'b.txt', 'path': '/lib/b.txt'}],
                   'pkg_format': 'rpm',
                   'src_name': 'p1src',
-                  'src_version': '1.0'
+                  'src_version': '1.0',
+                  'pkg_supplier': 'VMware'
                   }
         p = Package('p1')
         p.fill(p_dict)


### PR DESCRIPTION
This commit adds package supplier information as an attribute in the
package class for package objects. This commit also adds
`pkg_supplier` attribute values as `PackageSupplier` field values in
Tag Value and JSON SPDX documents .

For some package managers (like PyPI), there is only one feasible
supplier (PyPI) and this value is set as a constant string (PyPI). For
others, like rpm, the string is determined using the `/etc/os-release`
file based on the Linux Distro providing the packages. While this is
not a perfect way to determine the distro/distributor, it is satisfactory
to satisfty the NTIA minimum elements for the upcoming EO 14028.
We decided to use the distro as the supplier based on conversations
had on the SPDX mailing list[1].

[1] https://lists.spdx.org/g/Spdx-tech/message/4942

Resolves #1205
