### PR TITLE
Correctly parse and report local image names

### DIFF
--- a/tern/analyze/default/container/image.py
+++ b/tern/analyze/default/container/image.py
@@ -26,13 +26,14 @@ logger = logging.getLogger(constants.logger_name)
 
 def load_full_image(image_tag_string, image_type='oci', load_until_layer=0):
     """Create image object from image name and tag and return the object.
-    The kind of image object is created based on the image_type.
+    * The kind of image object is created based on the image_type.
     image_type = oci OR docker
-    Loads only as many layers as needed."""
+    * Loads only as many layers as needed.
+    * Remove docker-daemon prefix for local images"""
     if image_type == 'oci':
-        image = OCIImage(image_tag_string)
+        image = OCIImage(image_tag_string.replace('docker-daemon:', ''))
     elif image_type == 'docker':
-        image = DockerImage(image_tag_string)
+        image = DockerImage(image_tag_string.replace('docker-daemon:', ''))
     failure_origin = formats.image_load_failure.format(
         testimage=image.repotag)
     try:


### PR DESCRIPTION
A recent commit[1] added the ability to analyze local images by adding the `docker-daemon:` string before the image name. While this works from an analysis point of view, it yields the incorrect string for the container name in Tern's reporting. As a fix, this new commit removes the `docker-daemon` string when instantiating a new OCIImage or DockerImage object, yielding the correct image name in the reports.

[1]https://github.com/tern-tools/tern/commit/40b981ce54578a7bd6fc5e19e8ded455fa9a98fc

Resolves #1214
Resolves #1212