### PR TITLE
Change pacman and go pkg_format to mirror PURL

### DIFF
--- a/tern/analyze/default/command_lib/base.yml
+++ b/tern/analyze/default/command_lib/base.yml
@@ -187,7 +187,7 @@ apk:
 
 # pacman ----------------------------------------------------------------------
 pacman:
-  pkg_format: 'pkg.tar.xz'
+  pkg_format: 'alpm'
   os_guess:
     - 'Arch Linux'
   path:
@@ -509,7 +509,7 @@ npm:
     delimiter: "LICF"
 # golang----------------------------------------------------------------------
 go:
-  pkg_format: 'go'
+  pkg_format: 'golang'
   os_guess:
     - 'None'
   path:


### PR DESCRIPTION
A package object's `pkg_format` attribute is used in the default report, as well as to determine when a license value should be retrieved from the `pkg_licesnes` attribute value (i.e.
tern/formats/default/generator.py). Moving forward, we can also use the `pkg_format` as a purl type. This commit changes the go and pacman binary pkg_formats to align with the purl types[1] in the purl specification.

[1]https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst

Works towards: #1206