### PR TITLE
Add package architecture info to data model

### DIFF
--- a/tern/analyze/default/bundle.py
+++ b/tern/analyze/default/bundle.py
@@ -53,7 +53,8 @@ def convert_to_pkg_dicts(attr_lists):
                'files': 'files',
                'src_name': 'source_names',
                'src_version': 'source_versions',
-               'pkg_supplier': 'pkg_suppliers'}
+               'pkg_supplier': 'pkg_suppliers',
+               'arch': 'archs'}
     pkg_list = []
     len_names = len(attr_lists['names'])
     # make a list of keys that correspond with package property names

--- a/tern/analyze/default/command_lib/base.yml
+++ b/tern/analyze/default/command_lib/base.yml
@@ -52,6 +52,13 @@ tdnf:
           - 'pkgs=`tdnf list installed | cut -f1 -d"."`'
           - 'for p in $pkgs; do tdnf info $p | head -10 | tail -1 | cut -f2 -d":" | xargs; done'
     delimiter: "\n"
+  archs:
+    invoke:
+      1:
+        container:
+          - 'tdnf check-update > /dev/null'
+          - 'tdnf list installed | cut -f2 -d"." | cut -f1 -d" "'
+    delimiter: "\n"
   files: {}
   proj_urls:
     invoke:
@@ -87,6 +94,12 @@ dpkg:
       1:
         container:
           - "dpkg-query -W -f '${Version}\n'"
+    delimiter: "\n"
+  archs:
+    invoke:
+      1:
+        container:
+          - "dpkg-query -W -f '${Architecture}\n'"
     delimiter: "\n"
   pkg_suppliers:
     invoke:
@@ -155,6 +168,13 @@ apk:
           # use double quotes when using awk
           - "pkgs=`apk info 2>/dev/null`"
           - "for p in $pkgs; do lic=`apk info $p 2>/dev/null | head -1 | awk '{print $1}'`; echo $lic | sed -e \"s/^$p-//\"; done"
+    delimiter: "\n"
+  archs:
+    invoke:
+      1:
+        container:
+          - "pkgs=`apk info 2>/dev/null`"
+          - "for p in $pkgs; do apk -a info $p --print-arch; done"
     delimiter: "\n"
   pkg_suppliers:
     invoke:
@@ -273,6 +293,12 @@ rpm:
       1:
         container:
           - 'rpm --query --all --queryformat "%{license}\n" 2>/dev/null'
+    delimiter: "\n"
+  archs:
+    invoke:
+      1:
+        container:
+          - 'rpm --query --all --queryformat "%{arch}\n" 2>/dev/null'
     delimiter: "\n"
   source_names:
     invoke:
@@ -559,6 +585,13 @@ distroless:
         host:
           - "files=`ls var/lib/dpkg/status.d`"
           - "for f in $files; do grep -oP '^Version: \\K.*$' var/lib/dpkg/status.d/$f; done"
+    delimiter: "\n"
+  archs:
+    invoke:
+      1:
+        host:
+          - "files=`ls var/lib/dpkg/status.d`"
+          - "for f in $files; do grep -oP '^Architecture: \\K.*$' var/lib/dpkg/status.d/$f; done"
     delimiter: "\n"
   copyrights:
     invoke:

--- a/tern/analyze/default/command_lib/command_lib.py
+++ b/tern/analyze/default/command_lib/command_lib.py
@@ -37,10 +37,10 @@ with open(os.path.abspath(snippet_file), encoding='utf-8') as f:
     command_lib['snippets'] = yaml.safe_load(f)
 # list of package information keys that the command library can accomodate
 base_keys = {'names', 'versions', 'licenses', 'source_names',
-             'source_versions', 'pkg_suppliers', 'copyrights',
+             'source_versions', 'pkg_suppliers', 'archs', 'copyrights',
              'proj_urls', 'srcs', 'files'}
 package_keys = {'name', 'version', 'license', 'src_name', 'src_version',
-               'pkg_supplier', 'copyright', 'proj_url', 'src', 'files'}
+               'pkg_supplier', 'arch', 'copyright', 'proj_url', 'src', 'files'}
 
 # global logger
 logger = logging.getLogger(constants.logger_name)

--- a/tern/classes/package.py
+++ b/tern/classes/package.py
@@ -25,7 +25,8 @@ class Package:
         src_name: the source package associated with the binary package
         src_version: the source package version
         pkg_supplier: the package distributor according to SPDX 7.5;
-        required to create NTIA compliant SPDX docs
+          required to create NTIA compliant SPDX docs
+        arch: architecture the package was built for
 
     methods:
         to_dict: returns a dict representation of the instance
@@ -50,6 +51,7 @@ class Package:
         self.__src_name = ''
         self.__src_version = ''
         self.__pkg_supplier = ''
+        self.__arch = ''
 
     @property
     def name(self):
@@ -154,6 +156,14 @@ class Package:
     @pkg_supplier.setter
     def pkg_supplier(self, pkg_supplier):
         self.__pkg_supplier = pkg_supplier
+
+    @property
+    def arch(self):
+        return self.__arch
+
+    @arch.setter
+    def arch(self, arch):
+        self.__arch = arch
 
     def get_file_paths(self):
         """Return a list of paths of all the files in a package"""

--- a/tests/test_class_package.py
+++ b/tests/test_class_package.py
@@ -26,6 +26,7 @@ class TestClassPackage(unittest.TestCase):
         self.p1.src_name = 'p1src'
         self.p1.src_version = '1.0'
         self.p1.pkg_supplier = 'VMware'
+        self.p1.arch = 'x86_64'
 
         self.p2 = Package('p2')
 
@@ -82,6 +83,7 @@ class TestClassPackage(unittest.TestCase):
         self.assertEqual(self.p1.src_name, 'p1src')
         self.assertEqual(self.p1.src_version, '1.0')
         self.assertEqual(self.p1.pkg_supplier, 'VMware')
+        self.assertEqual(self.p1.arch, 'x86_64')
 
     def testAddFile(self):
         p1 = Package('package')
@@ -135,6 +137,7 @@ class TestClassPackage(unittest.TestCase):
         self.assertEqual(a_dict['src_name'], 'p1src')
         self.assertEqual(a_dict['src_version'], '1.0')
         self.assertEqual(a_dict['pkg_supplier'], 'VMware')
+        self.assertEqual(a_dict['arch'], 'x86_64')
 
     def testToDictTemplate(self):
         template1 = TestTemplate1()
@@ -181,7 +184,8 @@ class TestClassPackage(unittest.TestCase):
                   'pkg_format': 'rpm',
                   'src_name': 'p1src',
                   'src_version': '1.0',
-                  'pkg_supplier': 'VMware'
+                  'pkg_supplier': 'VMware',
+                  'arch': 'x86_64'
                   }
         p = Package('p1')
         p.fill(p_dict)


### PR DESCRIPTION
This commit adds package architecture information to Tern's data model by collecting it during analysis.

Many purl types[1] include an architecture qualifier key. Having this attribute available in Tern's data model will making creating and reporting purls easier and more accurate.

[1]https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst

Works towards #1206