### PR TITLE
Add purl information to SPDX reports

### DIFF
--- a/tern/analyze/default/command_lib/base.yml
+++ b/tern/analyze/default/command_lib/base.yml
@@ -59,6 +59,15 @@ tdnf:
           - 'tdnf check-update > /dev/null'
           - 'tdnf list installed | cut -f2 -d"." | cut -f1 -d" "'
     delimiter: "\n"
+  pkg_suppliers:
+    invoke:
+      1:
+        container:
+          - 'tdnf check-update > /dev/null'
+          - "distro=`/bin/cat /etc/os-release | grep NAME | sed -n '1p' | cut -f 2 -d '=' | cut -d '\"' -f2`"
+          - 'pkgs=`tdnf list installed | cut -f1 -d"."`'
+          - "for p in $pkgs; do echo $distro; done"
+    delimiter: "\n"
   files: {}
   proj_urls:
     invoke:
@@ -180,8 +189,9 @@ apk:
     invoke:
       1:
         container:
+          - "distro=`/bin/cat /etc/os-release | grep NAME | sed -n '1p' | cut -f 2 -d '=' | cut -d '\"' -f2`"
           - "pkgs=`apk info 2>/dev/null`"
-          - "for p in $pkgs; do echo 'Alpine Linux'; done"
+          - "for p in $pkgs; do echo $distro; done"
     delimiter: "\n"
   licenses:
     invoke:
@@ -363,7 +373,7 @@ pip:
       1:
         container:
           - "pkgs=`pip list --format=freeze 2> /dev/null | cut -f1 -d'='`"
-          - "for p in $pkgs; do echo 'PyPI'; done"
+          - "for p in $pkgs; do echo 'Python Package Index'; done"
     delimiter: "\n"
   licenses:
     invoke:
@@ -413,7 +423,7 @@ pip3:
       1:
         container:
           - "pkgs=`pip3 list --format=freeze 2> /dev/null | cut -f1 -d'='`"
-          - "for p in $pkgs; do echo 'PyPI'; done"
+          - "for p in $pkgs; do echo 'Python Package Index'; done"
     delimiter: "\n"
   licenses:
     invoke:

--- a/tern/formats/spdx/spdxjson/package_helpers.py
+++ b/tern/formats/spdx/spdxjson/package_helpers.py
@@ -74,9 +74,14 @@ def get_package_dict(package, template):
             mapping['PackageLicenseDeclared']),
         'copyrightText': mapping['PackageCopyrightText'] if
         mapping['PackageCopyrightText'] else 'NONE',
-        'comment': get_package_comment(package)
     }
-
+    # Only add package PURL if it exists
+    if spdx_common.get_purl(package):
+        package_dict['externalRefs'] = [{'referenceCategory': 'PACKAGE-MANAGER',
+                                         'referenceLocator': spdx_common.get_purl(package),
+                                         'referenceType': 'purl'}]
+    # Put package comment after any potential externalRefs
+    package_dict['comment'] = get_package_comment(package)
     return package_dict
 
 

--- a/tern/formats/spdx/spdxtagvalue/package_helpers.py
+++ b/tern/formats/spdx/spdxtagvalue/package_helpers.py
@@ -115,6 +115,10 @@ def get_package_block(package_obj, template):
             message=mapping['PackageCopyrightText']) + '\n'
     else:
         block += 'PackageCopyrightText: NONE\n'
+    # Package URL
+    if spdx_common.get_purl(package_obj):
+        block += 'ExternalRef: PACKAGE-MANAGER purl {}\n'.format(
+                spdx_common.get_purl(package_obj))
     # Package Comments
     block += get_package_comment(package_obj)
     return block


### PR DESCRIPTION
This commit adds a new function, `get_purl()` to spdx_common.py which
uses the packageurl library to generate purl strings for given package
objects. The namespace for certain purls is determined using the
/etc/os-release file information collected via the `pkg_suppliers` field
in base.yml.

This commit then adds purl strings as external references[1] to both
SPDX tag value and SPDX json reports.

[1]https://spdx.github.io/spdx-spec/v2.3/package-information/#721-external-reference-field

Resolves https://github.com/tern-tools/tern/issues/1206

Signed-off-by: Rose Judge <rjudge@vmware.com>
Signed-off-by: Ivana Atanasova <iyovcheva@vmware.com>