### PR TITLE
Remove slashes from SPDX package refs

### DIFF
--- a/tern/formats/spdx/spdx_common.py
+++ b/tern/formats/spdx/spdx_common.py
@@ -163,9 +163,9 @@ def get_package_spdxref(package_obj):
                                                  ver=src_ver)
     # replace all the strings that SPDX doesn't like
     # allowed characters are: letters, numbers, "." and "-"
-    clean_pkg_ref = re.sub(r'[:+~_]', r'-', pkg_ref)
+    clean_pkg_ref = re.sub(r'[:+~_/]', r'-', pkg_ref)
     if src_ref:
-        clean_src_ref = re.sub(r'[:+~]', r'-', src_ref)
+        clean_src_ref = re.sub(r'[:+~/]', r'-', src_ref)
         return 'SPDXRef-{}'.format(clean_pkg_ref), 'SPDXRef-{}'.format(clean_src_ref)
     return 'SPDXRef-{}'.format(clean_pkg_ref), ''
 


### PR DESCRIPTION
SPDX does not allow slashes in SPDXRefs. Golang pacakges, however, tend to have slashes in their package names which is what Tern uses to create the SPDXRefs. This commit replaces slashes in refs with dashes.

Resolves #1220