### PR TITLE
Accomodate updated Scancode attribute names

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,8 @@ NOTE: Neither the Docker container nor the Vagrant image has any of the extensio
 ## Scancode<a name="scancode">
 [scancode-toolkit](https://github.com/nexB/scancode-toolkit) is a license analysis tool that "detects licenses, copyrights, package manifests and direct dependencies and more both in source code and binary files". Note that Scancode currently works on Python 3.6 to 3.9. Be sure to check what python version you are using below.
 
+**NOTE** Installation issues have been [reported](https://github.com/nexB/scancode-toolkit/issues/3205) on macOS on M1 and Linux on ARM for Scancode>=31.0.0. If you are wanting to run Tern + Scancode in either of these environments, you will need to install `scancode-toolkit-mini`.
+
 1. Install system dependencies for Scancode (refer to the [Scancode GitHub repo](https://github.com/nexB/scancode-toolkit) for instructions)
 
 2. Setup a python virtual environment
@@ -359,6 +361,10 @@ $ source bin/activate
 3. Install tern and scancode
 ```
 $ pip install tern scancode-toolkit
+```
+<br> If you are using macOS on M1 or Linux on ARM, run:</br>
+```
+$ pip install tern scancode-toolkit-mini
 ```
 4. Run tern with scancode
 ```

--- a/tern/formats/spdx/spdx_common.py
+++ b/tern/formats/spdx/spdx_common.py
@@ -241,10 +241,10 @@ def get_purl(package_obj):
             purl_namespace = package_obj.pkg_supplier.split(' ')[1].lower()
         else:
             purl_namespace = package_obj.pkg_supplier.split(' ')[0].lower()
-            # TODO- this might need adjusting for alpm. Currently can't test on M1 
-    purl = PackageURL(purl_type, purl_namespace, package_obj.name.lower(), package_obj.version,
-                      qualifiers={'arch': package_obj.arch if package_obj.arch else ''})
     try:
+        # TODO- this might need adjusting for alpm. Currently can't test on M1
+        purl = PackageURL(purl_type, purl_namespace, package_obj.name.lower(), package_obj.version,
+                          qualifiers={'arch': package_obj.arch if package_obj.arch else ''})
         return purl.to_string()
     except ValueError:
         return ''


### PR DESCRIPTION
Scancode v31.0.0 includes changes[1] to JSON output attribute names which was causing processing KeyErrors when Tern would run with Scancode. Scancode v32.0.0 also includes changes[2] to license_detection output which was similarly causing parsing KeyErrors when Tern ran with Scancode. This commit adds code that can accomodate the new attribute property names in the newer versions of Scancode, as well as the older value names (in case we have users still using older Scancode versions). At some point in the future, it probably makes sense to re-visit some of these changes and see if we want to continue to support older versions of scancode.

This commit also has small changes that updated the README instructions for how to install newer Scancode versions on M1/ARM hardware and also fixes a small bug that was causing purl generation to fail when Scancode doesn't detect a package format.

[1]https://github.com/nexB/scancode-toolkit/blob/e3099637b195daca54942df9f695f58990097896/CHANGELOG.rst#v3100---2022-08-17

[2]https://github.com/nexB/scancode-toolkit/blob/e3099637b195daca54942df9f695f58990097896/CHANGELOG.rst#license-detection

Resolves #1202