### PR TITLE
Update `samples` dfiles to use correct base images

### DIFF
--- a/samples/debian_vim/Dockerfile
+++ b/samples/debian_vim/Dockerfile
@@ -1,4 +1,4 @@
 # Copyright (c) 2017 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-FROM debian:jessie
+FROM debian:bullseye
 RUN apt-get update && apt-get install -y vim && apt-get clean

--- a/samples/photon_3_layers/Dockerfile
+++ b/samples/photon_3_layers/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright (c) 2017 VMware, Inc. All Rights Reserved
 # SPDX-License-Identifier: BSD-2-Clause
-FROM vmware/photon2:GA                 
+FROM photon:3.0
 RUN tyum install -y git && tyum clean all
 RUN tyum install -y vim && tyum clean all

--- a/samples/photon_git/Dockerfile
+++ b/samples/photon_git/Dockerfile
@@ -1,4 +1,4 @@
 # Copyright (c) 2017 VMware, Inc. All Rights Reserved
 # SPDX-License-Identifier: BSD-2-Clause
-FROM vmware/photon:1.0                 
+FROM photon:5.0
 RUN tyum install -y git && tyum clean all

--- a/samples/photon_openjre/Dockerfile
+++ b/samples/photon_openjre/Dockerfile
@@ -1,4 +1,4 @@
 # Copyright (c) 2017 VMware, Inc. All Rights Reserved
 # SPDX-License-Identifier: BSD-2-Clause
-FROM vmware/photon:1.0                 
+FROM photon:5.0 
 RUN tyum install -y openjre && tyum clean all


### PR DESCRIPTION
There were several Dockerfiles in the `samples` repo that were referring to base images that either no longer exist or are much out of date (5+ years). This commit updates the base images in those files so that Tern/Docker can build and analyze them.

Resolves #1235